### PR TITLE
Fix broken link to Nuxt nitro route rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ export default defineNuxtConfig({
 
 ### Configure sitemap.xml entries
 
-To change the behavior of sitemap.xml entries, you can use [Nitro route rules](https://v3.nuxtjs.org/docs/directory-structure/nitro/#route-rules). 
+To change the behavior of sitemap.xml entries, you can use [Nitro route rules](https://nuxt.com/docs/api/configuration/nuxt-config/#routerules). 
 
 _nuxt.config.ts_
 


### PR DESCRIPTION
The current link to Nitro route rules is broken, i've updated it!

<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Fix README.md link to Nitro route rules

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
