### PR TITLE
fix: add url prefixes if `i18n.pages` is used

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -13,7 +13,7 @@ import {
 import { defu } from 'defu'
 import { createRouter as createRadixRouter, toRouteMatcher } from 'radix3'
 import chalk from 'chalk'
-import { withBase, withoutBase, withoutTrailingSlash } from 'ufo'
+import { joinURL, withBase, withoutBase, withoutTrailingSlash } from 'ufo'
 import { globby } from 'globby'
 import type { CreateFilterOptions } from './runtime/util/urlFilter'
 import { buildSitemap, buildSitemapIndex } from './runtime/util/builder'
@@ -142,11 +142,11 @@ export default defineNuxtModule<ModuleOptions>({
             const alternatives = Object.keys(pageLocales).filter(l => l !== locale)
               .map(l => ({
                 hreflang: l,
-                href: pageLocales[l],
+                href: nuxtI18nConfig?.strategy !== 'no_prefix' ? joinURL(l, pageLocales[l]) : pageLocales[l],
               }))
             if (Array.isArray(config.urls)) {
               config.urls.push({
-                loc: pageLocales[locale],
+                loc: nuxtI18nConfig?.strategy === 'prefix' ? joinURL(locale, pageLocales[locale]) : pageLocales[locale],
                 alternatives,
               })
             }


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

i18n prefixes were not added to the sitemap loc and alternate urls.

### Linked Issues

Fixes #54 and probably #48 too.

### Additional context

Do we want to support the i18n strategy `prefix_and_default`?
