### PR TITLE
fix: docs url on sidebar

### DIFF
--- a/src/runtime/routes/sitemap.xsl.ts
+++ b/src/runtime/routes/sitemap.xsl.ts
@@ -26,7 +26,7 @@ export default defineEventHandler(async (e) => {
   const isShowingCanonical = typeof canonicalQuery !== 'undefined' && canonicalQuery !== 'false'
 
   const conditionalTips = [
-    'You are looking at a <a href="https://developer.mozilla.org/en-US/docs/Web/XSLT/Transforming_XML_with_XSLT/An_Overview" style="color: #398465" target="_blank">XML stylesheet</a>. Read the  <a href="nuxtseo.com/sitemap/guides/customising-ui" style="color: #398465" target="_blank">docs</a> to learn how to customize it.',
+    'You are looking at a <a href="https://developer.mozilla.org/en-US/docs/Web/XSLT/Transforming_XML_with_XSLT/An_Overview" style="color: #398465" target="_blank">XML stylesheet</a>. Read the <a href="https://nuxtseo.com/sitemap/guides/customising-ui" style="color: #398465" target="_blank">docs</a> to learn how to customize it.',
     `URLs missing? Check the <a href="${withQuery('/api/__sitemap__/debug', { sitemap: sitemapName })}" style="color: #398465" target="_blank">debug endpoint</a>`,
   ]
   if (!isShowingCanonical) {


### PR DESCRIPTION
### Description

Old url was a relative path and would therefore route locally (e.g. old url would route to "http://localhost:3000/nuxtseo.com/sitemap/guides/customising-ui"). I've simply added an "https://" schema so you're properly routed to the docs.

I've also removed a spare space before the link.

### Linked Issues

Quick fix, no issue created (sorry!)
