### PR TITLE
fix: prefix strategy with i18n.pages

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -11,7 +11,7 @@ import {
   hasNuxtModuleCompatibility,
   useLogger,
 } from '@nuxt/kit'
-import { withBase, withoutLeadingSlash } from 'ufo'
+import { joinURL, withBase, withoutLeadingSlash } from 'ufo'
 import { installNuxtSiteConfig } from 'nuxt-site-config-kit'
 import type { NuxtI18nOptions } from '@nuxtjs/i18n/dist/module'
 import { defu } from 'defu'
@@ -169,13 +169,13 @@ export default defineNuxtModule<ModuleOptions>({
             const alternatives = Object.keys(pageLocales)
               .map(l => ({
                 hreflang: normalisedLocales.find(nl => nl.code === l)?.iso || l,
-                href: pageLocales[l],
+                href: nuxtI18nConfig?.strategy !== 'no_prefix' ? joinURL(l, pageLocales[l]) : pageLocales[l],
               }))
             if (alternatives.length && nuxtI18nConfig.defaultLocale && pageLocales[nuxtI18nConfig.defaultLocale])
               alternatives.push({ hreflang: 'x-default', href: pageLocales[nuxtI18nConfig.defaultLocale] })
             i18nPagesSources.urls!.push({
               _sitemap: locale.iso || locale.code,
-              loc: pageLocales[localeCode],
+              loc: nuxtI18nConfig?.strategy === 'prefix' ? joinURL(localeCode, pageLocales[localeCode]) : pageLocales[localeCode],
               alternatives,
             })
           }


### PR DESCRIPTION
### Description

Following the migration to v4.x, the locale prefix with the i18n.pages + prefix strategy has ceased to function. This PR addresses the issue by incorporating the locale in cases where the "prefix" strategy is utilized with i18n.pages. Additionally, it ensures compatibility with alternate links.

### Linked Issues
https://github.com/harlan-zw/nuxt-simple-sitemap/issues/175

### Additional context
Built upon [this PR](https://github.com/harlan-zw/nuxt-simple-sitemap/pull/56)

This PR specifically modifies the behavior of the 'prefix' strategy in relation to i18n.pages (i18nPagesSources).

### Screenshots
Before:
![image](https://github.com/harlan-zw/nuxt-simple-sitemap/assets/20051792/d1272a32-df56-4948-a181-e3d1aa555d4a)


After:
![image](https://github.com/harlan-zw/nuxt-simple-sitemap/assets/20051792/55db53e9-9b65-46f7-93fb-418e593c9015)