### PR TITLE
fix: replace ampersand char with &amp; entity

### DIFF
--- a/src/runtime/routes/sitemap.xsl.ts
+++ b/src/runtime/routes/sitemap.xsl.ts
@@ -21,7 +21,7 @@ export default defineEventHandler(async (e) => {
   const referrer = getHeader(e, 'Referer')! || '/'
   const isNotIndexButHasIndex = referrer !== fixPath('/sitemap.xml') && parseURL(referrer).pathname.endsWith('-sitemap.xml')
   const sitemapName = parseURL(referrer).pathname.split('/').pop()?.split('-sitemap')[0] || fallbackSitemapName
-  const title = `${siteName}${sitemapName !== 'sitemap.xml' ? ` - ${sitemapName === 'sitemap_index.xml' ? 'index' : sitemapName}` : ''}`
+  const title = `${siteName}${sitemapName !== 'sitemap.xml' ? ` - ${sitemapName === 'sitemap_index.xml' ? 'index' : sitemapName}` : ''}`.replace(/&/g, '&amp;')
 
   // we need to tell the user their site url and allow them to render the sitemap with the canonical url
   // check if referrer has the query


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
When the site name contains an ampersand (&) the xsl parser fails because the xsl becomes invalid.

### Linked Issues

fixes #182 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
