### PR TITLE
fix(filters): new regexp inc/exc way.

### DIFF
--- a/.playground/nuxt.config.ts
+++ b/.playground/nuxt.config.ts
@@ -112,7 +112,7 @@ export default defineNuxtConfig({
           '/api/sitemap-foo',
           'https://example.com/invalid.json',
         ],
-        exclude: ['/en/blog/**', '/fr/blog/**', '/blog/**'],
+        exclude: ['/en/blog/**', '/fr/blog/**', '/blog/**', { regex: '.*hide.me.*' }],
         urls: [
           {
             loc: '/about',

--- a/.playground/nuxt.config.ts
+++ b/.playground/nuxt.config.ts
@@ -112,7 +112,7 @@ export default defineNuxtConfig({
           '/api/sitemap-foo',
           'https://example.com/invalid.json',
         ],
-        exclude: ['/en/blog/**', '/fr/blog/**', '/blog/**', { regex: '/.*hide-me.*/g' }, { regex: '/.*hide-me.*/' }],
+        exclude: ['/en/blog/**', '/fr/blog/**', '/blog/**', /.*hide-me.*/g],
         urls: [
           {
             loc: '/about',

--- a/.playground/nuxt.config.ts
+++ b/.playground/nuxt.config.ts
@@ -112,7 +112,7 @@ export default defineNuxtConfig({
           '/api/sitemap-foo',
           'https://example.com/invalid.json',
         ],
-        exclude: ['/en/blog/**', '/fr/blog/**', '/blog/**', { regex: '.*hide.me.*' }],
+        exclude: ['/en/blog/**', '/fr/blog/**', '/blog/**', { regex: '/.*hide-me.*/g' }, { regex: '/.*hide-me.*/' }],
         urls: [
           {
             loc: '/about',

--- a/.playground/pages/hide-me.vue
+++ b/.playground/pages/hide-me.vue
@@ -1,0 +1,4 @@
+<template>
+    <div>hide-me</div>
+  </template>
+  

--- a/src/module.ts
+++ b/src/module.ts
@@ -34,7 +34,7 @@ import type {
 import { convertNuxtPagesToSitemapEntries, generateExtraRoutesFromNuxtConfig, resolveUrls } from './util/nuxtSitemap'
 import { createNitroPromise, createPagesPromise, extendTypes, getNuxtModuleOptions } from './util/kit'
 import { setupPrerenderHandler } from './prerender'
-import { isValidFilter, mergeOnKey, normaliseFilters } from './runtime/utils'
+import { isValidFilter, mergeOnKey, normaliseRegexp } from './runtime/utils'
 import { setupDevToolsUI } from './devtools'
 import { normaliseDate } from './runtime/sitemap/urlset/normalise'
 import { generatePathForI18nPages, splitPathForI18nLocales } from './util/i18n'
@@ -345,8 +345,8 @@ declare module 'vue-router' {
 
     // we need to normalize the RegExp to a string
     // because of the useRuntimeConfig can't jsonify it
-    config.include = (config.include || []).filter(r => isValidFilter(r)).map(r => normaliseFilters(r))
-    config.exclude = (config.exclude || []).filter(r => isValidFilter(r)).map(r => normaliseFilters(r))
+    config.include = (config.include || []).filter(r => isValidFilter(r)).map(r => normaliseRegexp(r))
+    config.exclude = (config.exclude || []).filter(r => isValidFilter(r)).map(r => normaliseRegexp(r))
 
     if (usingMultiSitemaps) {
       addServerHandler({

--- a/src/module.ts
+++ b/src/module.ts
@@ -369,7 +369,9 @@ declare module 'vue-router' {
               _hasSourceChunk: typeof definition.urls !== 'undefined' || definition.sources?.length || !!definition.dynamicUrlsApiEndpoint,
             },
             { ...definition, urls: undefined, sources: undefined },
-            { include: config.include, exclude: config.exclude },
+            { include: (config.include || []).map(r => r instanceof RegExp ? { regex: r.toString() } : r), 
+              exclude: (config.exclude || []).map(r => r instanceof RegExp ? { regex: r.toString() } : r)
+            },
           ) as ModuleRuntimeConfig['sitemaps'][string]
         }
       }

--- a/src/module.ts
+++ b/src/module.ts
@@ -390,7 +390,6 @@ declare module 'vue-router' {
       }
     }
     else {
-      console.log("NOT Using multi sitemaps")
       // note: we don't need urls for the root sitemap, only child sitemaps
       sitemaps[config.sitemapName] = <SitemapDefinition> {
         sitemapName: config.sitemapName,

--- a/src/runtime/sitemap/urlset/filter.ts
+++ b/src/runtime/sitemap/urlset/filter.ts
@@ -4,6 +4,7 @@ import type { ModuleRuntimeConfig, ResolvedSitemapUrl, SitemapDefinition } from 
 
 interface RegexObjectType {
   regex: string
+  flags?: string
 }
 interface CreateFilterOptions {
   include?: (string | RegexObjectType)[]
@@ -19,7 +20,7 @@ function createFilter(options: CreateFilterOptions = {}): (path: string) => bool
   return function (path: string): boolean {
     for (const v of [{ rules: exclude, result: false }, { rules: include, result: true }]) {
       const regexRules = (v.rules.filter(r => typeof r === 'object' && r.regex) as RegexObjectType[])
-                                 .map((r) => new RegExp(r.regex)) as RegExp[]
+                                 .map((r) => new RegExp(r.regex, r.flags)) as RegExp[]
 
       if (regexRules.some(r => r.test(path)))
         return v.result

--- a/src/runtime/sitemap/urlset/filter.ts
+++ b/src/runtime/sitemap/urlset/filter.ts
@@ -6,8 +6,8 @@ interface RegexObjectType {
   regex: string
 }
 interface CreateFilterOptions {
-  include?: (string | RegexObjectType)[]
-  exclude?: (string | RegexObjectType)[]
+  include?: (string | RegExp | RegexObjectType)[]
+  exclude?: (string | RegExp | RegexObjectType)[]
 }
 
 function createFilter(options: CreateFilterOptions = {}): (path: string) => boolean {
@@ -23,8 +23,7 @@ function createFilter(options: CreateFilterOptions = {}): (path: string) => bool
                                  .map((r) => {
                                   const match = r.regex.match(regexPattern)
                                   if (!match || match.length < 3){
-                                    console.warn(`Invalid regex rule: ${r.regex}`)
-                                    return new RegExp('')
+                                    throw new Error(`Invalid regex rule: ${r.regex}`)
                                   }
                                   return new RegExp(match[1], match[2])}) as RegExp[]
 

--- a/src/runtime/sitemap/urlset/filter.ts
+++ b/src/runtime/sitemap/urlset/filter.ts
@@ -2,9 +2,12 @@ import { parseURL } from 'ufo'
 import { createRouter, toRouteMatcher } from 'radix3'
 import type { ModuleRuntimeConfig, ResolvedSitemapUrl, SitemapDefinition } from '../../types'
 
+interface RegexObjectType {
+  regex: string
+}
 interface CreateFilterOptions {
-  include?: (string | RegExp)[]
-  exclude?: (string | RegExp)[]
+  include?: (string | RegexObjectType)[]
+  exclude?: (string | RegexObjectType)[]
 }
 
 function createFilter(options: CreateFilterOptions = {}): (path: string) => boolean {
@@ -15,7 +18,9 @@ function createFilter(options: CreateFilterOptions = {}): (path: string) => bool
 
   return function (path: string): boolean {
     for (const v of [{ rules: exclude, result: false }, { rules: include, result: true }]) {
-      const regexRules = v.rules.filter(r => r instanceof RegExp) as RegExp[]
+      const regexRules = (v.rules.filter(r => typeof r === 'object' && r.regex) as RegexObjectType[])
+                                 .map((r) => new RegExp(r.regex)) as RegExp[]
+
       if (regexRules.some(r => r.test(path)))
         return v.result
 

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -195,17 +195,25 @@ export interface SitemapIndexEntry {
   lastmod?: string
 }
 
+export interface RegexObjectType {
+  regex: string
+}
+
+export interface FilterTypes {
+  include?: (string | RegExp | RegexObjectType)
+  exclude?: (string | RegExp | RegexObjectType)
+}
 export type ResolvedSitemapUrl = Omit<SitemapUrl, 'url'> & Required<Pick<SitemapUrl, 'loc'>>
 
 export interface SitemapDefinition {
   /**
    * A collection include patterns for filtering which URLs end up in the sitemap.
    */
-  include?: (string | RegExp)[]
+  include?: (FilterTypes['include'])[]
   /**
    * A collection exclude patterns for filtering which URLs end up in the sitemap.
    */
-  exclude?: (string | RegExp)[]
+  exclude?: (FilterTypes['exclude'])[]
   /**
    * Should the sitemap be generated using global sources.
    *

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -200,8 +200,8 @@ export interface RegexObjectType {
 }
 
 export interface FilterTypes {
-  include?: (string | RegExp | RegexObjectType)
-  exclude?: (string | RegExp | RegexObjectType)
+  include: (string | RegExp | RegexObjectType)
+  exclude: (string | RegExp | RegexObjectType)
 }
 export type ResolvedSitemapUrl = Omit<SitemapUrl, 'url'> & Required<Pick<SitemapUrl, 'loc'>>
 

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -34,25 +34,20 @@ export function isValidFilter(filter: FilterTypes['include'] | FilterTypes['excl
 }
 
 /**
- * Transform the RegeExp into a valid { regex: string }
+ * Transform the RegeExp into RegexObjectType
  * @param filter string | RegExp | RegexObjectType
  * @return Object | string
  */
 
-export function normaliseFilters(filter: FilterTypes['include'] | FilterTypes['exclude']): RegexObjectType | string | undefined {
+export function normaliseRegexp(filter: FilterTypes['include'] | FilterTypes['exclude']) : FilterTypes['include'] | FilterTypes['exclude']{
   
-  if (!filter) return undefined
-  
-  else if (filter instanceof RegExp)
+  if (filter instanceof RegExp)
     return { regex: filter.toString() }
 
-  else if (typeof filter === 'string' || typeof filter === 'object' && filter.regex && typeof filter.regex === 'string')
-    return filter
-
-  else if (filter.regex as any instanceof RegExp)
+  else if ( typeof filter === 'object' && filter.regex && filter.regex as any instanceof RegExp)
     return { regex: filter.regex.toString() }
 
-  return undefined
+  return filter 
 }
 
 /**

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -1,5 +1,7 @@
 import { createDefu } from 'defu'
+import type { FilterTypes, RegexObjectType } from './types'
 
+const regexPattern = /\/(.*?)\/([gimsuy]*)$/
 const merger = createDefu((obj, key, value) => {
   // merge arrays using a set
   if (Array.isArray(obj[key]) && Array.isArray(value))
@@ -16,4 +18,54 @@ export function mergeOnKey<T, K extends keyof T>(arr: T[], key: K) {
     res[k] = merger(item, res[k] || {})
   })
   return Object.values(res)
+}
+
+/**
+ * Check if a filter is valid, otherwise exclude it
+ * @param filter string | RegExp | RegexObjectType
+ * 
+ */
+
+export function isValidFilter(filter: FilterTypes['include'] | FilterTypes['exclude']) {
+  if (typeof filter === 'string' || filter instanceof RegExp || typeof filter === 'object' && filter.regex)
+    return true
+
+  return false
+}
+
+/**
+ * Transform the RegeExp into a valid { regex: string }
+ * @param filter string | RegExp | RegexObjectType
+ * @return Object | string
+ */
+
+export function normaliseFilters(filter: FilterTypes['include'] | FilterTypes['exclude']): RegexObjectType | string | undefined {
+  
+  if (!filter) return undefined
+  
+  else if (filter instanceof RegExp)
+    return { regex: filter.toString() }
+
+  else if (typeof filter === 'string' || typeof filter === 'object' && filter.regex && typeof filter.regex === 'string')
+    return filter
+
+  else if (filter.regex as any instanceof RegExp)
+    return { regex: filter.regex.toString() }
+
+  return undefined
+}
+
+/**
+ * Transform a literal notation string regex to RegExp
+ * @param rule
+ * @return RegExp
+ */
+export function transformIntoRegex(rule: RegexObjectType | RegExp | string): RegExp | string {
+  if (rule instanceof RegExp || typeof rule === 'string')
+    return rule
+  const match = rule.regex.match(regexPattern)
+  if (!match || match.length < 3){
+    throw new Error(`Invalid regex rule: ${rule.regex}`)
+  }
+  return new RegExp(match[1], match[2])
 }

--- a/src/util/i18n.ts
+++ b/src/util/i18n.ts
@@ -1,7 +1,7 @@
 import type { NuxtI18nOptions } from '@nuxtjs/i18n/dist/module'
 import type { Strategies } from 'vue-i18n-routing'
 import { joinURL } from 'ufo'
-import type { AutoI18nConfig } from '../runtime/types'
+import type { AutoI18nConfig, RegexObjectType } from '../runtime/types'
 
 export interface StrategyProps {
   localeCode: string
@@ -10,7 +10,7 @@ export interface StrategyProps {
   forcedStrategy?: Strategies
 }
 
-export function splitPathForI18nLocales(path: string | RegExp, autoI18n: AutoI18nConfig) {
+export function splitPathForI18nLocales(path: string | RegExp | RegexObjectType, autoI18n: AutoI18nConfig) {
   const locales = autoI18n.strategy === 'prefix_except_default' ? autoI18n.locales.filter(l => l.code !== autoI18n.defaultLocale) : autoI18n.locales
   if (typeof path !== 'string' || path.startsWith('/api') || path.startsWith('/_nuxt'))
     return path

--- a/test/integration/i18n/filtering-regexp.test.ts
+++ b/test/integration/i18n/filtering-regexp.test.ts
@@ -1,25 +1,23 @@
-import { describe, expect, it } from 'vitest'
-import { createResolver } from '@nuxt/kit'
-import { $fetch, setup } from '@nuxt/test-utils'
+import { describe, expect, it } from "vitest";
+import { createResolver } from "@nuxt/kit";
+import { $fetch, setup } from "@nuxt/test-utils";
 
-const { resolve } = createResolver(import.meta.url)
+const { resolve } = createResolver(import.meta.url);
 
 await setup({
-  rootDir: resolve('../../fixtures/i18n'),
+  rootDir: resolve("../../fixtures/i18n"),
   nuxtConfig: {
     sitemap: {
-      exclude: [
-        { regex: '/.*test.*/g' },
-      ],
+      exclude: [/.*test.*/g],
     },
   },
-})
-describe('i18n filtering with regexp', () => {
-  it('basic', async () => {
-    let sitemap = await $fetch('/en-US-sitemap.xml')
+});
+describe("i18n filtering with regexp", () => {
+  it("basic", async () => {
+    let sitemap = await $fetch("/en-US-sitemap.xml");
 
     // strip lastmod
-    sitemap = sitemap.replace(/<lastmod>.*<\/lastmod>/g, '')
+    sitemap = sitemap.replace(/<lastmod>.*<\/lastmod>/g, "");
 
     expect(sitemap).toMatchInlineSnapshot(`
       "<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet type="text/xsl" href="/__sitemap__/style.xsl"?>
@@ -43,6 +41,6 @@ describe('i18n filtering with regexp', () => {
               <xhtml:link rel="alternate" hreflang="fr-FR" href="https://nuxtseo.com/fr/__sitemap/url" />
           </url>
       </urlset>"
-    `)
-  }, 60000)
-})
+    `);
+  }, 60000);
+});

--- a/test/integration/i18n/filtering-regexp.test.ts
+++ b/test/integration/i18n/filtering-regexp.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { createResolver } from '@nuxt/kit'
+import { $fetch, setup } from '@nuxt/test-utils'
+
+const { resolve } = createResolver(import.meta.url)
+
+await setup({
+  rootDir: resolve('../../fixtures/i18n'),
+  nuxtConfig: {
+    sitemap: {
+      exclude: [
+        { regex: '/.*test.*/g' },
+      ],
+    },
+  },
+})
+describe('i18n filtering with regexp', () => {
+  it('basic', async () => {
+    let sitemap = await $fetch('/en-US-sitemap.xml')
+
+    // strip lastmod
+    sitemap = sitemap.replace(/<lastmod>.*<\/lastmod>/g, '')
+
+    expect(sitemap).toMatchInlineSnapshot(`
+      "<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet type="text/xsl" href="/__sitemap__/style.xsl"?>
+      <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd http://www.google.com/schemas/sitemap-image/1.1 http://www.google.com/schemas/sitemap-image/1.1/sitemap-image.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+          <url>
+              <loc>https://nuxtseo.com/en</loc>
+              <xhtml:link rel="alternate" hreflang="en-US" href="https://nuxtseo.com/en" />
+              <xhtml:link rel="alternate" hreflang="es-ES" href="https://nuxtseo.com/es" />
+              <xhtml:link rel="alternate" hreflang="fr-FR" href="https://nuxtseo.com/fr" />
+              <xhtml:link rel="alternate" hreflang="x-default" href="https://nuxtseo.com/en" />
+          </url>
+          <url>
+              <loc>https://nuxtseo.com/no-i18n</loc>
+          </url>
+          <url>
+              <loc>https://nuxtseo.com/en/__sitemap/url</loc>
+              <changefreq>weekly</changefreq>
+              <xhtml:link rel="alternate" hreflang="x-default" href="https://nuxtseo.com/en/__sitemap/url" />
+              <xhtml:link rel="alternate" hreflang="en-US" href="https://nuxtseo.com/en/__sitemap/url" />
+              <xhtml:link rel="alternate" hreflang="es-ES" href="https://nuxtseo.com/es/__sitemap/url" />
+              <xhtml:link rel="alternate" hreflang="fr-FR" href="https://nuxtseo.com/fr/__sitemap/url" />
+          </url>
+      </urlset>"
+    `)
+  }, 60000)
+})


### PR DESCRIPTION
### Description
The useRuntimeConfig property in the nuxt.config.js file cannot parse a RegExp and transform it into an empty list.

### Linked Issues
https://github.com/harlan-zw/nuxt-simple-sitemap/issues/184

### Additional context
The new way to add the regular expression is by using an object with the property 'regex' and a string with literal notation.
Example:
```
sitemap: {
      exclude: [ 'something/to/exclude', { regex: '/.*hide-me.*/g' } ],
},
```
