### PR TITLE
fix(content): exclude YAML navigation files from the sitemap

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -378,7 +378,7 @@ declare module 'vue-router' {
           updatedAt?: string
         }
         nuxtV3Collections.add(ctx.collection.name)
-        if (ctx.file.stem.endsWith('/.navigation')) {
+        if (ctx.file.path.endsWith('/.navigation')) {
           return
         }
         if (!('sitemap' in ctx.collection.fields)) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

Currently, YAML files used to configure navigation in Nuxt Content are being included in the generated sitemap. These files are not intended to be indexed by search engines and should be excluded by default.

![Capture d’écran 2025-02-18 à 15 52 15](https://github.com/user-attachments/assets/20729801-6539-4d00-8fea-83e112a759c0)


#### Expected behavior:

YAML files (e.g., .navigation.yml) should not be added to the sitemap.
https://content.nuxt.com/docs/getting-started/migration#_diryml-files-are-renamed-to-navigationyml

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
