### PR TITLE
fix: chunking support with URL filtering

### DIFF
--- a/src/runtime/server/sitemap/builder/sitemap.ts
+++ b/src/runtime/server/sitemap/builder/sitemap.ts
@@ -315,8 +315,11 @@ export async function buildSitemapUrls(sitemap: SitemapDefinition, resolvers: Ni
   const filteredUrls = enhancedUrls.filter((e) => {
     if (e._sitemap === false)
       return false
-    if (isMultiSitemap && e._sitemap && sitemap.sitemapName)
+    if (isMultiSitemap && e._sitemap && sitemap.sitemapName) {
+      if (sitemap._isChunking)
+        return sitemap.sitemapName.startsWith(e._sitemap + '-')
       return e._sitemap === sitemap.sitemapName
+    }
     return true
   })
   // 4. sort


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->
Resolves #521 
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
URL Filtering now checks if chunking is enabled. If so, it checks if the sitemap requested starts with the expected sitemap followed by a '-' to mimic the format 'name-0'
<!-- Why is this change required? What problem does it solve? -->
Chunked sitemaps would return 0 URLs