### PR TITLE
fix:  readSourcesFromFilesystem unicode escape error on windows

### DIFF
--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -73,7 +73,7 @@ export async function readSourcesFromFilesystem(filename) {
   if (!import.meta.prerender) {
     return null
   }
-  const path = join('${runtimeAssetsPath}', filename)
+  const path = join(${JSON.stringify(runtimeAssetsPath)}, filename)
   const data = await readFile(path, 'utf-8').catch(() => null)
   return data ? JSON.parse(data) : null
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

This error occurs on Windows when there is a folder whose name starts with u.

```
ERROR  RollupError: virtual:#sitemap-virtual/read-sources.mjs (9:34): Expected unicode escape (Note that you need plugins to import files that are not JavaScript)                          nitro 11:36:17  

 7:     return null
 8:   }
 9:   const path = join('C:\Users\user\workspace...
                                      ^
10:   const data = await readFile(path, 'utf-8').catch(() => null)
11:   return data ? JSON.parse(data) : null
```