### PR TITLE
fix: use snake_case for ImageEntry.geo_location to match XML spec

### DIFF
--- a/docs/content/2.guides/2.images-videos.md
+++ b/docs/content/2.guides/2.images-videos.md
@@ -34,7 +34,7 @@ export default defineNuxtConfig({
           {
             loc: 'https://example.com/image.jpg',
             caption: 'My image caption',
-            geoLocation: 'My image geo location',
+            geo_location: 'My image geo location',
             title: 'My image title',
             license: 'My image license',
           }

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -431,7 +431,7 @@ export interface GoogleNewsEntry {
 export interface ImageEntry {
   loc: string | URL
   caption?: string
-  geoLocation?: string
+  geo_location?: string
   title?: string
   license?: string | URL
 }


### PR DESCRIPTION
Isolated fix from https://github.com/nuxt-modules/sitemap/pull/496

While this does introduce a breaking change, I doubt anyone is actually using this, if they were then it was already broken.