### PR TITLE
docs: remove server `tsconfig.json` tip from dynamic URLs guide

### DIFF
--- a/docs/content/2.guides/2.dynamic-urls.md
+++ b/docs/content/2.guides/2.dynamic-urls.md
@@ -149,10 +149,6 @@ export default defineSitemapEventHandler(async () => {
 
 ::
 
-:::tip
-Ensure you have a `server/tsconfig.json` file for proper TypeScript type support.
-:::
-
 **Step 2: Configure the endpoint**
 
 Add your custom endpoint to the sitemap configuration:


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This removes a tip about needing `server/tsconfig.json` for TypeScript support in the server directory as it is no longer the case in Nuxt 4 by default.

<img width="692" height="148" alt="image" src="https://github.com/user-attachments/assets/ca5932e7-c033-4535-b903-47bbfa1f38c4" />


<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
