### PR TITLE
feat: build-time hook `sitemap:prerender:done`

### DIFF
--- a/docs/content/4.api/1.nuxt-hooks.md
+++ b/docs/content/4.api/1.nuxt-hooks.md
@@ -5,15 +5,14 @@ description: Build-time Nuxt hooks provided by @nuxtjs/sitemap.
 
 ## `'sitemap:prerender:done'`{lang="ts"}
 
-**Type:** `(ctx: { options: ModuleRuntimeConfig, sitemaps: { name: string, content: string }[], prerenderRoute: (route: string) => PrerenderRoute | undefined }) => void | Promise<void>`{lang="ts"}
+**Type:** `(ctx: { options: ModuleRuntimeConfig, sitemaps: { name: string, readonly content: string }[] }) => void | Promise<void>`{lang="ts"}
 
 Called after sitemap prerendering completes. Useful for modules that need to emit extra files based on the generated sitemaps.
 
 **Context:**
 
 - `options` - The resolved module runtime configuration
-- `sitemaps` - Array of rendered sitemaps with their route name and XML content
-- `prerenderRoute` - Function to look up a prerendered route by path, returns `PrerenderRoute` from Nitro or `undefined` if not found
+- `sitemaps` - Array of rendered sitemaps with their route name and XML content (content is lazily loaded from disk)
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({

--- a/src/module.ts
+++ b/src/module.ts
@@ -13,7 +13,7 @@ import {
 import { joinURL, withBase, withLeadingSlash, withoutLeadingSlash, withoutTrailingSlash, withTrailingSlash } from 'ufo'
 import { installNuxtSiteConfig } from 'nuxt-site-config/kit'
 import { defu } from 'defu'
-import type { NitroRouteConfig, PrerenderRoute } from 'nitropack/types'
+import type { NitroRouteConfig } from 'nitropack/types'
 import { readPackageJSON } from 'pkg-types'
 import { dirname, relative } from 'pathe'
 import type { FileAfterParseHook } from '@nuxt/content'
@@ -52,8 +52,7 @@ export interface ModuleHooks {
    */
   'sitemap:prerender:done': (ctx: {
     options: ModuleRuntimeConfig
-    sitemaps: { name: string, content: string }[]
-    prerenderRoute: (route: string) => PrerenderRoute | undefined
+    sitemaps: { name: string, readonly content: string }[]
   }) => void | Promise<void>
 }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Allows modules who want to emit something _after_ the sitemap to have access to fully resolved URLs.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
