### PR TITLE
fix(i18n): allow named multi-sitemap with i18n data (#486)

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -262,17 +262,57 @@ export default defineNuxtModule<ModuleOptions>({
       }
       let canI18nMap = config.sitemaps !== false && nuxtI18nConfig.strategy !== 'no_prefix'
       if (typeof config.sitemaps === 'object') {
-        const isSitemapIndexOnly = typeof config.sitemaps.index !== 'undefined' && Object.keys(config.sitemaps).length === 1
-        if (!isSitemapIndexOnly)
+        const sitemapEntries = Object.entries(config.sitemaps).filter(([k]) => k !== 'index')
+        const isSitemapIndexOnly = sitemapEntries.length === 0
+        // Allow i18n mapping if any sitemap has includeAppSources
+        const hasIncludeAppSources = sitemapEntries.some(([_, v]) => v && typeof v === 'object' && (v as SitemapDefinition).includeAppSources)
+        if (!isSitemapIndexOnly && !hasIncludeAppSources)
           canI18nMap = false
       }
       // if they haven't set `sitemaps` explicitly then we can set it up automatically for them
       if (canI18nMap && resolvedAutoI18n) {
+        const existingSitemaps: Record<string, unknown> = typeof config.sitemaps === 'object' ? config.sitemaps : {}
+        const nonI18nSitemaps: Record<string, unknown> = {}
+        const mergedConfig: { exclude?: FilterInput[], include?: FilterInput[] } = {}
+
+        // Process existing sitemaps - separate includeAppSources from others
+        for (const [name, cfg] of Object.entries(existingSitemaps)) {
+          if (name === 'index')
+            continue
+          if (cfg && typeof cfg === 'object' && (cfg as SitemapDefinition).includeAppSources) {
+            // Merge exclude/include from includeAppSources sitemaps into locale sitemaps
+            const typedCfg = cfg as SitemapDefinition
+            if (typedCfg.exclude)
+              mergedConfig.exclude = [...(mergedConfig.exclude || []), ...typedCfg.exclude]
+            if (typedCfg.include)
+              mergedConfig.include = [...(mergedConfig.include || []), ...typedCfg.include]
+          }
+          else {
+            // Keep non-includeAppSources sitemaps as-is
+            nonI18nSitemaps[name] = cfg
+          }
+        }
+
+        // Build new sitemaps config
+        const newSitemaps: Record<string, unknown> = {
+          index: [...((existingSitemaps.index as unknown[]) || []), ...(config.appendSitemaps || [])],
+        }
+
+        // Create per-locale sitemaps with merged config
+        for (const locale of resolvedAutoI18n.locales) {
+          newSitemaps[locale._sitemap] = {
+            includeAppSources: true,
+            ...(mergedConfig.exclude?.length && { exclude: mergedConfig.exclude }),
+            ...(mergedConfig.include?.length && { include: mergedConfig.include }),
+          }
+        }
+
+        // Add back non-i18n sitemaps
+        Object.assign(newSitemaps, nonI18nSitemaps)
+
         // @ts-expect-error untyped
-        config.sitemaps = { index: [...(config.sitemaps?.index || []), ...(config.appendSitemaps || [])] }
-        for (const locale of resolvedAutoI18n.locales)
-          // @ts-expect-error untyped
-          config.sitemaps[locale._sitemap] = { includeAppSources: true }
+        config.sitemaps = newSitemaps
+
         isI18nMapped = true
         usingMultiSitemaps = true
       }

--- a/test/e2e/i18n/custom-sitemaps-i18n.test.ts
+++ b/test/e2e/i18n/custom-sitemaps-i18n.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { createResolver } from '@nuxt/kit'
+import { $fetch, setup } from '@nuxt/test-utils'
+
+const { resolve } = createResolver(import.meta.url)
+
+// Test for issue #486: Automatic I18n Multi Sitemap + custom sitemaps not working
+await setup({
+  rootDir: resolve('../../fixtures/i18n'),
+  nuxtConfig: {
+    sitemap: {
+      sitemaps: {
+        pages: {
+          // This should be expanded to per-locale sitemaps (en-US, es-ES, fr-FR)
+          includeAppSources: true,
+          exclude: ['/secret/**'],
+        },
+        custom: {
+          // This should stay as a single sitemap
+          sources: ['/__sitemap'],
+        },
+      },
+    },
+  },
+})
+
+describe('i18n with custom sitemaps (#486)', () => {
+  it('generates sitemap index with locale sitemaps and custom sitemap', async () => {
+    const index = await $fetch('/sitemap_index.xml')
+
+    // Should have locale sitemaps (en-US, es-ES, fr-FR) plus the custom sitemap
+    expect(index).toContain('en-US.xml')
+    expect(index).toContain('es-ES.xml')
+    expect(index).toContain('fr-FR.xml')
+    expect(index).toContain('custom.xml')
+
+    // Should NOT have a "pages" sitemap (it should be expanded to locales)
+    expect(index).not.toContain('pages.xml')
+  })
+
+  it('locale sitemap inherits exclude config from custom sitemap', async () => {
+    const enSitemap = await $fetch('/__sitemap__/en-US.xml')
+
+    // Should have normal pages
+    expect(enSitemap).toContain('/en')
+
+    // The exclude pattern should be applied (no /secret/** URLs)
+    expect(enSitemap).not.toContain('/secret')
+  })
+
+  it('custom sitemap without includeAppSources stays separate', async () => {
+    const customSitemap = await $fetch('/__sitemap__/custom.xml')
+
+    // Should have content from the source
+    expect(customSitemap).toContain('urlset')
+  })
+
+  it('locale sitemaps have proper i18n alternatives', async () => {
+    const frSitemap = await $fetch('/__sitemap__/fr-FR.xml')
+
+    // Should have French URLs with alternatives
+    expect(frSitemap).toContain('/fr')
+    expect(frSitemap).toContain('hreflang')
+    expect(frSitemap).toContain('x-default')
+  })
+}, 60000)

--- a/test/e2e/i18n/filtering-include.test.ts
+++ b/test/e2e/i18n/filtering-include.test.ts
@@ -4,6 +4,8 @@ import { $fetch, setup } from '@nuxt/test-utils'
 
 const { resolve } = createResolver(import.meta.url)
 
+// With i18n + includeAppSources, sitemaps are automatically expanded to per-locale sitemaps
+// The include filter is applied to each locale sitemap
 await setup({
   rootDir: resolve('../../fixtures/i18n'),
   nuxtConfig: {
@@ -11,48 +13,33 @@ await setup({
       sitemaps: {
         main: {
           includeAppSources: true,
-          include: ['/fr', '/en', '/fr/test', '/en/test'],
+          include: ['/', '/test'],
         },
       },
     },
   },
 })
 describe('i18n filtering with include', () => {
-  it('basic', async () => {
-    const sitemap = await $fetch('/__sitemap__/main.xml')
+  it('generates per-locale sitemaps with include filter applied', async () => {
+    // With the fix for #486, includeAppSources sitemaps are expanded to locale sitemaps
+    const index = await $fetch('/sitemap_index.xml')
+    expect(index).toContain('en-US.xml')
+    expect(index).toContain('fr-FR.xml')
+    expect(index).toContain('es-ES.xml')
+    // main.xml should NOT exist - it's expanded to locale sitemaps
+    expect(index).not.toContain('main.xml')
 
-    expect(sitemap).toMatchInlineSnapshot(`
-      "<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet type="text/xsl" href="/__sitemap__/style.xsl"?>
-      <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd http://www.google.com/schemas/sitemap-image/1.1 http://www.google.com/schemas/sitemap-image/1.1/sitemap-image.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-          <url>
-              <loc>https://nuxtseo.com/en</loc>
-              <xhtml:link rel="alternate" hreflang="en-US" href="https://nuxtseo.com/en" />
-              <xhtml:link rel="alternate" hreflang="es-ES" href="https://nuxtseo.com/es" />
-              <xhtml:link rel="alternate" hreflang="fr-FR" href="https://nuxtseo.com/fr" />
-              <xhtml:link rel="alternate" hreflang="x-default" href="https://nuxtseo.com/en" />
-          </url>
-          <url>
-              <loc>https://nuxtseo.com/fr</loc>
-              <xhtml:link rel="alternate" hreflang="en-US" href="https://nuxtseo.com/en" />
-              <xhtml:link rel="alternate" hreflang="es-ES" href="https://nuxtseo.com/es" />
-              <xhtml:link rel="alternate" hreflang="fr-FR" href="https://nuxtseo.com/fr" />
-              <xhtml:link rel="alternate" hreflang="x-default" href="https://nuxtseo.com/en" />
-          </url>
-          <url>
-              <loc>https://nuxtseo.com/en/test</loc>
-              <xhtml:link rel="alternate" hreflang="en-US" href="https://nuxtseo.com/en/test" />
-              <xhtml:link rel="alternate" hreflang="es-ES" href="https://nuxtseo.com/es/test" />
-              <xhtml:link rel="alternate" hreflang="fr-FR" href="https://nuxtseo.com/fr/test" />
-              <xhtml:link rel="alternate" hreflang="x-default" href="https://nuxtseo.com/en/test" />
-          </url>
-          <url>
-              <loc>https://nuxtseo.com/fr/test</loc>
-              <xhtml:link rel="alternate" hreflang="en-US" href="https://nuxtseo.com/en/test" />
-              <xhtml:link rel="alternate" hreflang="es-ES" href="https://nuxtseo.com/es/test" />
-              <xhtml:link rel="alternate" hreflang="fr-FR" href="https://nuxtseo.com/fr/test" />
-              <xhtml:link rel="alternate" hreflang="x-default" href="https://nuxtseo.com/en/test" />
-          </url>
-      </urlset>"
-    `)
+    // English sitemap should have filtered URLs with alternatives
+    const enSitemap = await $fetch('/__sitemap__/en-US.xml')
+    expect(enSitemap).toContain('/en')
+    expect(enSitemap).toContain('/en/test')
+    expect(enSitemap).toContain('hreflang')
+    expect(enSitemap).toContain('x-default')
+
+    // French sitemap should have filtered URLs with alternatives
+    const frSitemap = await $fetch('/__sitemap__/fr-FR.xml')
+    expect(frSitemap).toContain('/fr')
+    expect(frSitemap).toContain('/fr/test')
+    expect(frSitemap).toContain('hreflang')
   }, 60000)
 })


### PR DESCRIPTION


<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When custom sitemaps with `includeAppSources: true` are defined, expand them to per-locale sitemaps instead of disabling i18n mapping.

- Check if any custom sitemap has `includeAppSources` before disabling i18n
- Expand includeAppSources sitemaps to per-locale sitemaps
- Merge exclude/include filters to all locale sitemaps
- Keep non-includeAppSources sitemaps as separate sitemaps

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
