### PR TITLE
docs: fix typos and add sitemap validator links

### DIFF
--- a/docs/content/0.getting-started/0.introduction.md
+++ b/docs/content/0.getting-started/0.introduction.md
@@ -36,3 +36,7 @@ Ready to get started? Check out the [installation guide](/docs/sitemap/getting-s
 - 🔄 SWR caching, route rules support
 - 🎨 Debug using the Nuxt DevTools integration or the XML Stylesheet
 - 🤝 Integrates seamlessly with Nuxt I18n and Nuxt Content
+
+::callout{icon="i-heroicons-wrench" to="/tools/xml-sitemap-validator"}
+**Validate your sitemap** - Use our free [XML Sitemap Validator](/tools/xml-sitemap-validator) to check structure and ensure Google compliance.
+::

--- a/docs/content/0.getting-started/3.troubleshooting.md
+++ b/docs/content/0.getting-started/3.troubleshooting.md
@@ -1,6 +1,6 @@
 ---
 title: "Troubleshooting Nuxt Sitemap"
-description: Create minimal reproductions for Nuxt Sitemap or just experiment with the module.
+description: Common issues and debugging tips for Nuxt Sitemap.
 navigation:
   title: 'Troubleshooting'
 relatedPages:
@@ -86,3 +86,7 @@ export default defineSitemapEventHandler(async () => {
 ```
 
 See [Handling Pre-Encoded URLs](/docs/sitemap/guides/dynamic-urls#handling-pre-encoded-urls) for more details.
+
+## Debugging Tools
+
+- [XML Sitemap Validator](/tools/xml-sitemap-validator) - Validate sitemap structure, check URL format, and test against Google requirements

--- a/docs/content/1.guides/5.prerendering.md
+++ b/docs/content/1.guides/5.prerendering.md
@@ -1,6 +1,6 @@
 ---
 title: Nuxt Prerendering
-description: Perender your pages and have them all automatically added to your sitemap.
+description: Prerender your pages and have them all automatically added to your sitemap.
 relatedPages:
   - path: /docs/sitemap/advanced/images-videos
     title: Images, Videos, News

--- a/docs/content/1.guides/6.best-practices.md
+++ b/docs/content/1.guides/6.best-practices.md
@@ -48,3 +48,7 @@ export default defineNuxtConfig({
 This is ideal for sites using `nuxt build` where content is static between deployments. If you're using a CMS that updates content without redeploying, you'll need runtime generation.
 
 Learn more in the [Zero Runtime](/docs/sitemap/guides/zero-runtime) guide.
+
+::callout{icon="i-heroicons-check-circle" to="/tools/xml-sitemap-validator"}
+**Check your sitemap** - Validate your sitemap meets Google requirements with our [XML Sitemap Validator](/tools/xml-sitemap-validator).
+::

--- a/docs/content/1.guides/7.submitting-sitemap.md
+++ b/docs/content/1.guides/7.submitting-sitemap.md
@@ -18,6 +18,10 @@ to submit your sitemap to Google Search Console.
 > Google Search Console is a free service offered by Google that helps you monitor, maintain, and troubleshoot
 your site's presence in Google Search results.
 
+::callout{icon="i-heroicons-shield-check" to="/tools/xml-sitemap-validator"}
+**Validate before submitting** - Use our [XML Sitemap Validator](/tools/xml-sitemap-validator) to check for errors before submitting to Google Search Console.
+::
+
 ## Submitting Sitemap
 
 Google provides a guide on [Submitting your Sitemap to Google](https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap) which is a great starting point.

--- a/docs/content/2.advanced/0.loc-data.md
+++ b/docs/content/2.advanced/0.loc-data.md
@@ -1,6 +1,6 @@
 ---
 title: Lastmod, Priority, and Changefreq
-description: Configure your sitemap entries with route rules.
+description: Configure lastmod, priority, and changefreq values for your sitemap entries.
 relatedPages:
   - path: /docs/sitemap/guides/best-practices
     title: Best Practices

--- a/docs/content/2.advanced/4.customising-ui.md
+++ b/docs/content/2.advanced/4.customising-ui.md
@@ -21,7 +21,7 @@ export default defineNuxtConfig({
     xsl: false
   }
 })
-````
+```
 
 ## Changing the columns
 


### PR DESCRIPTION
## Summary
- Fix "Perender" typo in prerendering.md description
- Fix 4-backtick code block in customising-ui.md  
- Improve troubleshooting.md and loc-data.md descriptions
- Add XML Sitemap Validator callouts to intro, troubleshooting, best-practices, and submitting-sitemap pages

## Test plan
- [ ] Verify typos are fixed
- [ ] Verify code block renders correctly
- [ ] Verify validator links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)