### PR TITLE
docs: fix internal links to use correct paths

### DIFF
--- a/docs/content/0.getting-started/0.introduction.md
+++ b/docs/content/0.getting-started/0.introduction.md
@@ -26,7 +26,7 @@ and easy to miss best practices.
 
 Nuxt Sitemap automatically generates the sitemap for you based on your site's content, including lastmod, image discovery and more.
 
-Ready to get started? Check out the [installation guide](/docs/sitemap/getting-started/installation) or learn more on the [Controlling Web Crawlers](/learn/controlling-crawlers) guide.
+Ready to get started? Check out the [installation guide](/docs/sitemap/getting-started/installation) or learn more on the [Controlling Web Crawlers](/learn-seo/nuxt/controlling-crawlers) guide.
 
 ## Features
 

--- a/docs/content/5.releases/7.v4.md
+++ b/docs/content/5.releases/7.v4.md
@@ -117,7 +117,7 @@ By default, app sources will no longer be included in multi sitemap implementati
 ### Removed deprecations
 
 - The hook `sitemap:prerender` has been removed. You should use `sitemap:resolved` instead.
-- The config `trailingSlash` and `siteUrl` has been removed. You should use site config, see [Setting Site Config](/docs/site-config/guides/setting-site-config).
+- The config `trailingSlash` and `siteUrl` has been removed. You should use site config, see [Setting Site Config](/docs/site-config/guides/how-it-works).
 - The config `autoAlternativeLangPrefixes` has been removed. If you'd like to set up automatic alternative language prefixes use `__i18nTransform`.
 
 ## Support my work


### PR DESCRIPTION
## Summary
- Update `/learn/` links to `/learn-seo/nuxt/`
- Fix `setting-site-config` → `how-it-works`

These links were causing unnecessary redirects on nuxtseo.com.

🤖 Generated with [Claude Code](https://claude.ai/code)