### PR TITLE
fix(types): use robots instead of deprecated index in route rules

### DIFF
--- a/src/runtime/server/sitemap/nitro.ts
+++ b/src/runtime/server/sitemap/nitro.ts
@@ -93,7 +93,6 @@ async function buildSitemapXml(event: H3Event, definition: SitemapDefinition, re
     // Skip invalid entries
     if (routeRules.sitemap === false)
       continue
-    // @ts-expect-error runtime types
     if (typeof routeRules.robots !== 'undefined' && !routeRules.robots)
       continue
 

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -13,11 +13,11 @@ declare module 'nitropack' {
     _sitemap?: SitemapUrl
   }
   interface NitroRouteRules {
-    index?: boolean
+    robots?: boolean
     sitemap?: SitemapItemDefaults | false
   }
   interface NitroRouteConfig {
-    index?: boolean
+    robots?: boolean
     sitemap?: SitemapItemDefaults | false
   }
   interface NitroRuntimeHooks {
@@ -34,11 +34,11 @@ declare module 'nitropack/types' {
     _sitemap?: SitemapUrl
   }
   interface NitroRouteRules {
-    index?: boolean
+    robots?: boolean
     sitemap?: SitemapItemDefaults | false
   }
   interface NitroRouteConfig {
-    index?: boolean
+    robots?: boolean
     sitemap?: SitemapItemDefaults | false
   }
   interface NitroRuntimeHooks {

--- a/test/types/templates.test-d.ts
+++ b/test/types/templates.test-d.ts
@@ -31,8 +31,8 @@ describe('nitropack augmentations', () => {
     expectTypeOf<NitroRouteRules['sitemap']>().toEqualTypeOf<SitemapItemDefaults | false | undefined>()
   })
 
-  it('NitroRouteRules.index is boolean', () => {
-    expectTypeOf<NitroRouteRules['index']>().toEqualTypeOf<boolean | undefined>()
+  it('NitroRouteRules.robots is boolean', () => {
+    expectTypeOf<NitroRouteRules['robots']>().toEqualTypeOf<boolean | undefined>()
   })
 
   it('NitroRouteConfig.sitemap is SitemapItemDefaults | false', () => {


### PR DESCRIPTION
## Description

Fixes #546

The v7 migration guide states that `index` was removed and users should use `robots` instead. However, the generated type declarations still use `index?: boolean`.

This PR updates the types to match the runtime behavior.

## Changes

- Updated `NitroRouteRules.index` → `NitroRouteRules.robots`
- Updated `NitroRouteConfig.index` → `NitroRouteConfig.robots`

Both in `nitropack` and `nitropack/types` module declarations.