### PR TITLE
docs(i18n): update multi sitemap docs to reflect custom sitemaps support

### DIFF
--- a/docs/content/1.guides/3.i18n.md
+++ b/docs/content/1.guides/3.i18n.md
@@ -25,7 +25,6 @@ The module supports two main modes for handling internationalized sitemaps:
 The module automatically generates a sitemap for each locale when:
 - You're not using the `no_prefix` strategy
 - Or you're using [Different Domains](https://i18n.nuxtjs.org/docs/v7/different-domains)
-- And you haven't manually configured the `sitemaps` option
 
 This generates the following structure:
 ```shell
@@ -39,6 +38,36 @@ Key features:
 - Includes [app sources](/docs/sitemap/getting-started/data-sources) automatically
 - The `nuxt:pages` source determines the correct `alternatives` for your pages
 - To disable app sources, set `excludeAppSources: true`
+
+#### Custom Sitemaps with I18n
+
+You can add custom sitemaps alongside the automatic i18n multi-sitemap. When any sitemap uses `includeAppSources: true`, the module still generates per-locale sitemaps and merges the `exclude`/`include` filters:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  sitemap: {
+    sitemaps: {
+      pages: {
+        includeAppSources: true,
+        exclude: ['/admin/**'],
+      },
+      posts: {
+        sources: ['/api/__sitemap__/posts'],
+      }
+    }
+  }
+})
+```
+
+This generates:
+```shell
+./sitemap_index.xml
+./en-pages.xml   # locale sitemap with /admin/** excluded
+./fr-pages.xml   # locale sitemap with /admin/** excluded
+./posts.xml      # custom sitemap (kept as-is)
+```
+
+The sitemap name is preserved with the format `{locale}-{name}`. Sitemaps without `includeAppSources` (like `posts`) remain as separate sitemaps.
 
 ### I18n Pages Mode
 


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #486

### ❓ Type of change

- [x] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The code fix for i18n multi sitemaps + custom sitemaps was already merged (63c20ac), but the documentation still states that automatic i18n multi sitemaps don't work when manually configuring the sitemaps option. Updated docs to reflect current behavior.