### PR TITLE
fix: patch unenv v2 process polyfill for Vercel Edge compatibility

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -45,6 +45,7 @@ import {
 } from './utils-internal/i18n'
 import { createNitroPromise, createPagesPromise, getNuxtModuleOptions } from './utils-internal/kit'
 import { convertNuxtPagesToSitemapEntries, generateExtraRoutesFromNuxtConfig, resolveUrls } from './utils-internal/nuxtSitemap'
+import { setupVercelEdgeFix } from './utils-internal/vercel-edge-fix'
 
 declare global {
   // eslint-disable-next-line vars-on-top
@@ -992,6 +993,9 @@ export async function readSourcesFromFilesystem() {
     })
 
     setupPrerenderHandler({ runtimeConfig, logger, generateGlobalSources, generateChildSources })
+
+    // Fix unenv v2 process polyfill breaking Vercel Edge (private class fields + Proxy)
+    setupVercelEdgeFix(nuxt)
 
     // suggest zeroRuntime when no dynamic sources detected
     if (!config.zeroRuntime && !nuxt.options.dev && !nuxt.options._prepare) {

--- a/src/runtime/server/plugins/compression.ts
+++ b/src/runtime/server/plugins/compression.ts
@@ -22,7 +22,7 @@ export default defineNitroPlugin((nitro) => {
 
     const body = typeof response.body === 'string' ? response.body : JSON.stringify(response.body)
     const stream = new Blob([body]).stream().pipeThrough(new CompressionStream(encoding))
-    response.body = Buffer.from(await new Response(stream).arrayBuffer())
+    response.body = new Uint8Array(await new Response(stream).arrayBuffer())
     setResponseHeader(event, 'Content-Encoding', encoding)
   })
 })

--- a/src/utils-internal/vercel-edge-fix.ts
+++ b/src/utils-internal/vercel-edge-fix.ts
@@ -1,0 +1,53 @@
+import { existsSync } from 'node:fs'
+import { readFile, writeFile } from 'node:fs/promises'
+import { join } from 'pathe'
+import { resolveNitroPreset } from './kit'
+
+const RE_REFLECT_HAS_MINIFIED = /Reflect\.has\(([\w$]+),([\w$]+)\)\?Reflect\.get\(\1,\2,([\w$]+)\):Reflect\.get\(([\w$]+),\2,\3\)/g
+
+/**
+ * Patches the compiled Vercel Edge server entry to fix unenv v2's process polyfill.
+ *
+ * unenv's Process class uses private fields (#stdin, #stdout, #stderr, #cwd) but the
+ * process polyfill wraps it in a Proxy. Vercel Edge's minimal process object causes
+ * property lookups to fall through to processModule, where `this` is the Proxy (not the
+ * Process instance), causing "Cannot read private member" errors.
+ *
+ * TODO: remove once https://github.com/unjs/unenv/issues/399 is fixed
+ */
+export function setupVercelEdgeFix(nuxt: { hooks: { hook: (name: string, fn: (...args: any[]) => any) => void } }) {
+  nuxt.hooks.hook('nitro:init', (nitro: any) => {
+    const target = resolveNitroPreset(nitro.options)
+    const normalizedTarget = target.replace(/_legacy$/, '')
+    if (normalizedTarget !== 'vercel-edge')
+      return
+
+    nitro.hooks.hook('compiled', async (_nitro: any) => {
+      const configuredEntry = nitro.options.rollupConfig?.output.entryFileNames
+      const serverEntry = join(
+        _nitro.options.output.serverDir,
+        typeof configuredEntry === 'string' ? configuredEntry : 'index.mjs',
+      )
+      if (!existsSync(serverEntry))
+        return
+
+      let contents = await readFile(serverEntry, 'utf-8')
+      const original = contents
+
+      // Fix unformatted output (tabs/newlines preserved by rollup)
+      contents = contents.replaceAll(
+        'return Reflect.get(target, prop, receiver);\n\t}\n\treturn Reflect.get(processModule, prop, receiver)',
+        'return Reflect.get(target, prop, receiver);\n\t}\n\treturn Reflect.get(processModule, prop, processModule)',
+      )
+
+      // Fix minified output (ternary form)
+      contents = contents.replace(
+        RE_REFLECT_HAS_MINIFIED,
+        'Reflect.has($1,$2)?Reflect.get($1,$2,$3):Reflect.get($4,$2,$4)',
+      )
+
+      if (contents !== original)
+        await writeFile(serverEntry, contents, { encoding: 'utf-8' })
+    })
+  })
+}


### PR DESCRIPTION
### 🔗 Linked issue

Resolves harlan-zw/nuxt-seo#511
Related to harlan-zw/nuxt-seo#494

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

unenv v2 (used by Nuxt 4) wraps its Process class in a Proxy with private fields (`#stdin`, `#stdout`, `#stderr`). On Vercel Edge, property lookups fall through to `processModule` with the Proxy as `this`, triggering "Cannot read private member" errors that crash all API routes. The `consola` package (used at runtime for logging) accesses `process.stdout`/`process.stderr`, which hits this path.

This patches the compiled server entry to fix the `Reflect.get` receiver (matching the approach already used in `nuxt-og-image`), and replaces `Buffer.from` with `Uint8Array` in the compression plugin for Edge runtime compatibility.

Upstream fix tracked at unjs/unenv#399; once landed these patches can be removed.