### PR TITLE
fix(content): filter .navigation paths and document i18n onUrl pattern

### DIFF
--- a/docs/content/1.guides/4.content.md
+++ b/docs/content/1.guides/4.content.md
@@ -88,7 +88,7 @@ The `filter` function receives the full content entry including your custom sche
 
 Use the `onUrl` callback to transform the sitemap entry for each item in a collection. The callback receives the resolved URL object; mutate it directly to change `loc`, `lastmod`, `priority`, or any other field.
 
-This is especially useful when a collection uses `prefix: ''` in its source config, which strips the directory prefix from content paths.
+This is especially useful when using per-locale collections with `@nuxtjs/i18n`. If a collection uses `prefix: '/'` or `prefix: ''` to strip the locale directory from content paths, the sitemap URLs will be missing the locale prefix. Use `onUrl` to re-add it:
 
 ```ts [content.config.ts]
 import { defineCollection, defineContentConfig } from '@nuxt/content'
@@ -99,19 +99,19 @@ export default defineContentConfig({
   collections: {
     content_en: defineCollection({
       type: 'page',
-      source: { include: 'en/**', prefix: '' },
+      source: { include: 'en/**', prefix: '/' },
       schema: z.object({
         sitemap: defineSitemapSchema(),
       }),
     }),
-    content_zh: defineCollection({
+    content_ja: defineCollection({
       type: 'page',
-      source: { include: 'zh/**', prefix: '' },
+      source: { include: 'ja/**', prefix: '/' },
       schema: z.object({
         sitemap: defineSitemapSchema({
-          name: 'content_zh',
+          name: 'content_ja',
           onUrl(url) {
-            url.loc = `/zh${url.loc}`
+            url.loc = `/ja${url.loc}`
           },
         }),
       }),
@@ -120,7 +120,7 @@ export default defineContentConfig({
 })
 ```
 
-Without `onUrl`, both collections would produce `loc: '/about'` for their `about.md` files. With the transform, the zh collection entries correctly produce `loc: '/zh/about'`.
+Without `onUrl`, both collections would produce `loc: '/about'` for their `about.md` files. With the transform, the ja collection entries correctly produce `loc: '/ja/about'`, allowing the i18n sitemap builder to assign them to the correct per-locale sitemap.
 
 The callback also receives the full content entry and collection name, so you can use any content field to drive sitemap values:
 
@@ -138,7 +138,7 @@ schema: z.object({
 ```
 
 ::important
-The `name` option must match the collection key exactly (e.g. if your collection key is `content_zh`, use `name: 'content_zh'`).
+The `name` option must match the collection key exactly (e.g. if your collection key is `content_ja`, use `name: 'content_ja'`).
 ::
 
 Due to current Nuxt Content v3 limitations, you must load the sitemap module before the content module.

--- a/src/runtime/server/routes/__sitemap__/nuxt-content-urls-v3.ts
+++ b/src/runtime/server/routes/__sitemap__/nuxt-content-urls-v3.ts
@@ -47,7 +47,7 @@ export default defineEventHandler(async (e) => {
     .flatMap(({ collection, entries }) => {
       const onUrl = onUrlFns?.get(collection)
       return entries
-        .filter(c => c.sitemap !== false && c.path)
+        .filter(c => c.sitemap !== false && c.path && !c.path.endsWith('.navigation'))
         .map((c) => {
           const url: Record<string, unknown> = {
             loc: c.path,


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #400

### ❓ Type of change

- [x] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Issue #400 reports two problems when using Nuxt Content v3 with i18n:

1. **`.navigation` files appearing in sitemaps.** The content v3 URL handler now filters paths ending with `.navigation` as defense-in-depth. While the `content:file:afterParse` hook already catches `.dot` files, some configurations can leak `.navigation.yml` paths through.

2. **Per-locale sitemaps containing identical content.** When per-locale collections strip their locale prefix (e.g., `include: "ja/**", prefix: "/"`), both collections produce identical un-prefixed paths. The i18n sitemap builder can't distinguish locales from path alone. The fix is to use the existing `onUrl` callback to re-add the locale prefix. Updated docs to clearly show this pattern with a complete i18n example.