### PR TITLE
fix: respect `autoI18n: false` to suppress hreflang tag generation

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -884,6 +884,7 @@ export default defineNuxtModule<ModuleOptions>({
           exclude: normalizeFilters(config.exclude) as (string | RegExp)[],
         },
         isI18nMicro: i18nModule === 'nuxt-i18n-micro',
+        autoI18n: !!resolvedAutoI18n,
       })
       if (!pageSource.length) {
         pageSource.push(nuxt.options.app.baseURL || '/')

--- a/src/utils-internal/nuxtSitemap.ts
+++ b/src/utils-internal/nuxtSitemap.ts
@@ -43,6 +43,7 @@ export interface NuxtPagesToSitemapEntriesOptions {
   isI18nMapped: boolean
   isI18nMicro: boolean
   filter: CreateFilterOptions
+  autoI18n: boolean
 }
 
 interface PageEntry extends SitemapUrl {
@@ -183,25 +184,29 @@ export function convertNuxtPagesToSitemapEntries(pages: NuxtPage[], config: Nuxt
       }).filter(Boolean)
     }
     return entries.map((entry) => {
-      const alternatives = entries.map((entry) => {
-        const locale = config.normalisedLocales.find(l => l.code === entry.locale)
-        // check if the locale has a iso code
-        if (!pathFilter(entry.loc))
-          return false
-        const href = locale?.domain ? withHttps(withBase(entry.loc, locale?.domain)) : entry.loc
-        return {
-          hreflang: locale?._hreflang,
-          href,
+      const alternatives = config.autoI18n
+        ? entries.map((entry) => {
+            const locale = config.normalisedLocales.find(l => l.code === entry.locale)
+            // check if the locale has a iso code
+            if (!pathFilter(entry.loc))
+              return false
+            const href = locale?.domain ? withHttps(withBase(entry.loc, locale?.domain)) : entry.loc
+            return {
+              hreflang: locale?._hreflang,
+              href,
+            }
+          }).filter(Boolean)
+        : []
+      if (config.autoI18n) {
+        const xDefault = entries.find(a => a.locale === config.defaultLocale)
+        if (xDefault && alternatives.length && pathFilter(xDefault.loc)) {
+          const locale = config.normalisedLocales.find(l => l.code === xDefault.locale)
+          const href = locale?.domain ? withHttps(withBase(xDefault.loc, locale?.domain)) : xDefault.loc
+          alternatives.push({
+            hreflang: 'x-default',
+            href,
+          })
         }
-      }).filter(Boolean)
-      const xDefault = entries.find(a => a.locale === config.defaultLocale)
-      if (xDefault && alternatives.length && pathFilter(xDefault.loc)) {
-        const locale = config.normalisedLocales.find(l => l.code === xDefault.locale)
-        const href = locale?.domain ? withHttps(withBase(xDefault.loc, locale?.domain)) : xDefault.loc
-        alternatives.push({
-          hreflang: 'x-default',
-          href,
-        })
       }
       const e = { ...entry }
       if (config.isI18nMapped) {
@@ -212,7 +217,7 @@ export function convertNuxtPagesToSitemapEntries(pages: NuxtPage[], config: Nuxt
       delete e.locale
       return {
         ...e,
-        alternatives,
+        ...(alternatives.length ? { alternatives } : {}),
       }
     })
   }).filter(Boolean).flat() as SitemapUrlInput[]

--- a/test/e2e/issues/issue-561.test.ts
+++ b/test/e2e/issues/issue-561.test.ts
@@ -19,7 +19,7 @@ describe('issue #561 - autoI18n: false generates empty sitemap', () => {
     expect(sitemap).not.toContain('sitemap_index')
   }, 60000)
 
-  it('should contain all locale routes with alternates', async () => {
+  it('should contain all locale routes without hreflang alternates', async () => {
     let sitemap = await $fetch('/sitemap.xml')
 
     // strip lastmod for cleaner assertions
@@ -39,8 +39,8 @@ describe('issue #561 - autoI18n: false generates empty sitemap', () => {
     expect(sitemap).toContain('/politique-de-confidentialite')
     expect(sitemap).toContain('/en/privacy-policy')
 
-    // should contain xhtml:link alternates
-    expect(sitemap).toContain('xhtml:link')
-    expect(sitemap).toContain('hreflang')
+    // autoI18n: false should suppress hreflang alternatives (#586)
+    expect(sitemap).not.toContain('xhtml:link')
+    expect(sitemap).not.toContain('hreflang')
   }, 60000)
 })

--- a/test/unit/parsePages.test.ts
+++ b/test/unit/parsePages.test.ts
@@ -204,6 +204,7 @@ describe('page parser', () => {
       normalisedLocales: normalizeLocales({ locales: [{ code: 'en' }, { code: 'fr' }] }),
       strategy: 'no_prefix',
       isI18nMicro: false,
+      autoI18n: true,
     })).toMatchInlineSnapshot(`
       [
         {
@@ -666,6 +667,7 @@ describe('page parser', () => {
       ] }),
       strategy: 'prefix_except_default',
       isI18nMicro: true,
+      autoI18n: true,
     })).toMatchInlineSnapshot(`
       [
         {
@@ -698,5 +700,27 @@ describe('page parser', () => {
         },
       ]
     `)
+  })
+
+  it('autoI18n false disables hreflang alternatives', () => {
+    const result = convertNuxtPagesToSitemapEntries(payload, {
+      filter: {
+        include: [],
+        exclude: [],
+      },
+      isI18nMapped: false,
+      autoLastmod: false,
+      defaultLocale: 'en',
+      normalisedLocales: normalizeLocales({ locales: [{ code: 'en' }, { code: 'fr' }] }),
+      strategy: 'no_prefix',
+      isI18nMicro: false,
+      autoI18n: false,
+    })
+    // no entry should have alternatives when autoI18n is false
+    for (const entry of result) {
+      if (typeof entry === 'string')
+        continue
+      expect(entry).not.toHaveProperty('alternatives')
+    }
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #586

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`convertNuxtPagesToSitemapEntries` was unconditionally generating hreflang alternatives for locale-grouped pages at build time. The runtime `resolveSitemapEntries` correctly skipped i18n processing when `autoI18n` was falsy, but the build-time page converter had no such check, so hreflang tags leaked into SSG output.

Added an `autoI18n` boolean to the page conversion options and gated alternatives generation on it. Includes a unit test verifying no alternatives appear when `autoI18n: false`.