### PR TITLE
fix: suppress hreflang extraction from HTML when `autoI18n: false`

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -807,6 +807,8 @@ export default defineNuxtModule<ModuleOptions>({
     }
     if (resolvedAutoI18n)
       runtimeConfig.autoI18n = resolvedAutoI18n
+    if (hasDisabledAutoI18n)
+      runtimeConfig.hasDisabledAutoI18n = true
     // @ts-expect-error untyped
     nuxt.options.runtimeConfig.sitemap = runtimeConfig
 

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -92,7 +92,8 @@ export async function readSourcesFromFilesystem(filename) {
         lastmod: true,
         // when autoI18n is enabled, let the sitemap builder generate alternatives
         // based on i18n config instead of extracting from HTML (which can be incomplete)
-        alternatives: !options.autoI18n,
+        // when autoI18n is explicitly disabled, don't extract alternatives from HTML at all
+        alternatives: !options.autoI18n && !options.hasDisabledAutoI18n,
         resolveUrl(s) {
           // if the match is relative
           return s.startsWith('/') ? withSiteUrl(s) : s

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -238,6 +238,7 @@ export interface ModuleRuntimeConfig extends Pick<ModuleOptions, 'sitemapsPathPr
   isNuxtContentDocumentDriven: boolean
   sitemaps: { index?: Pick<SitemapDefinition, 'sitemapName' | '_route'> & { sitemaps: SitemapIndexEntry[] } } & Record<string, Omit<SitemapDefinition, 'urls'> & { _hasSourceChunk?: boolean }>
   autoI18n?: AutoI18nConfig
+  hasDisabledAutoI18n?: boolean
   isMultiSitemap: boolean
   isI18nMapped: boolean
 }

--- a/test/e2e/issues/issue-588.test.ts
+++ b/test/e2e/issues/issue-588.test.ts
@@ -1,0 +1,29 @@
+import { createResolver } from '@nuxt/kit'
+import { $fetch, setup } from '@nuxt/test-utils'
+import { describe, expect, it } from 'vitest'
+
+const { resolve } = createResolver(import.meta.url)
+
+await setup({
+  rootDir: resolve('../../fixtures/issue-588'),
+  server: true,
+  dev: false,
+})
+
+describe('issue #588 - useHead hreflang should not leak into sitemap when autoI18n: false', () => {
+  it('should not contain hreflang alternates from useHead()', async () => {
+    const sitemap = await $fetch('/sitemap.xml')
+
+    // should contain all pages
+    expect(sitemap).toContain('https://example.com/')
+    expect(sitemap).toContain('https://example.com/about')
+    expect(sitemap).toContain('https://example.com/contact')
+
+    // autoI18n: false should suppress hreflang alternatives even when added via useHead()
+    expect(sitemap).not.toContain('xhtml:link')
+    expect(sitemap).not.toContain('hreflang')
+    expect(sitemap).not.toContain('example.de')
+    expect(sitemap).not.toContain('example.fr')
+    expect(sitemap).not.toContain('example.it')
+  }, 60000)
+})

--- a/test/fixtures/issue-588/nuxt.config.ts
+++ b/test/fixtures/issue-588/nuxt.config.ts
@@ -1,0 +1,20 @@
+import NuxtSitemap from '../../../src/module'
+
+export default defineNuxtConfig({
+  modules: [
+    NuxtSitemap,
+  ],
+
+  site: {
+    url: 'https://example.com',
+  },
+
+  compatibilityDate: '2024-07-22',
+
+  sitemap: {
+    autoI18n: false,
+    autoLastmod: false,
+    credits: false,
+    debug: true,
+  },
+})

--- a/test/fixtures/issue-588/pages/about.vue
+++ b/test/fixtures/issue-588/pages/about.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+useHead({
+  link: [
+    { rel: 'alternate', hreflang: 'de-DE', href: 'https://example.de/about' },
+    { rel: 'alternate', hreflang: 'fr-FR', href: 'https://example.fr/about' },
+    { rel: 'alternate', hreflang: 'it-IT', href: 'https://example.it/about' },
+  ],
+})
+</script>
+
+<template>
+  <div>
+    <h1>About</h1>
+  </div>
+</template>

--- a/test/fixtures/issue-588/pages/contact.vue
+++ b/test/fixtures/issue-588/pages/contact.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+useHead({
+  link: [
+    { rel: 'alternate', hreflang: 'de-DE', href: 'https://example.de/contact' },
+    { rel: 'alternate', hreflang: 'fr-FR', href: 'https://example.fr/contact' },
+    { rel: 'alternate', hreflang: 'it-IT', href: 'https://example.it/contact' },
+  ],
+})
+</script>
+
+<template>
+  <div>
+    <h1>Contact</h1>
+  </div>
+</template>

--- a/test/fixtures/issue-588/pages/index.vue
+++ b/test/fixtures/issue-588/pages/index.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    <h1>Home</h1>
+  </div>
+</template>

--- a/test/unit/parseHtmlExtractSitemapMeta.test.ts
+++ b/test/unit/parseHtmlExtractSitemapMeta.test.ts
@@ -368,4 +368,27 @@ describe('parseHtmlExtractSitemapMeta', () => {
     `)
     expect(none).toBe(null)
   })
+
+  it('extracts alternatives from hreflang links', () => {
+    const output = parseHtmlExtractSitemapMeta(`
+    <head>
+      <link rel="alternate" hreflang="de-DE" href="https://example.de/about">
+      <link rel="alternate" hreflang="fr-FR" href="https://example.fr/about">
+    </head>
+    `, { alternatives: true })
+    expect(output?.alternatives).toEqual([
+      { hreflang: 'de-DE', href: '/about' },
+      { hreflang: 'fr-FR', href: '/about' },
+    ])
+  })
+
+  it('skips alternatives when alternatives option is false', () => {
+    const output = parseHtmlExtractSitemapMeta(`
+    <head>
+      <link rel="alternate" hreflang="de-DE" href="https://example.de/about">
+      <link rel="alternate" hreflang="fr-FR" href="https://example.fr/about">
+    </head>
+    `, { alternatives: false })
+    expect(output?.alternatives).toBeUndefined()
+  })
 })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #588

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

When `autoI18n` is explicitly set to `false`, `<link rel="alternate" hreflang="...">` tags added via `useHead()` were still being extracted from prerendered HTML and injected into sitemap entries as `<xhtml:link>` alternates.

The root cause: `alternatives: !options.autoI18n` evaluated to `true` when `autoI18n` was `false`, enabling HTML extraction. The fix adds a `hasDisabledAutoI18n` flag to the runtime config so the prerender hook can distinguish "autoI18n not configured" from "autoI18n explicitly disabled".