### PR TITLE
fix: fallback to `article:published_time` for lastmod

### DIFF
--- a/src/utils/parseHtmlExtractSitemapMeta.ts
+++ b/src/utils/parseHtmlExtractSitemapMeta.ts
@@ -91,8 +91,11 @@ export function parseHtmlExtractSitemapMeta(html: string, options?: { images?: b
       if (options?.lastmod && element.name === 'meta') {
         const property = sanitizeString(attrs.property)
         const content = sanitizeString(attrs.content)
-        if (property === 'article:modified_time' && content && isValidDate(content)) {
-          articleModifiedTime = content
+        if ((property === 'article:modified_time' || property === 'article:published_time') && content && isValidDate(content)) {
+          // prioritize modified_time
+          if (property === 'article:modified_time' || !articleModifiedTime) {
+            articleModifiedTime = content
+          }
         }
       }
 


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Many blogs only set `article:published_time` without `article:modified_time`. Previously, lastmod extraction would miss these pages entirely. This change falls back to `published_time` when `modified_time` is absent, while still prioritizing `modified_time` when both are present.