### PR TITLE
fix: `chunkSize` config precedence over `chunks` number

### DIFF
--- a/src/runtime/server/sitemap/builder/sitemap-index.ts
+++ b/src/runtime/server/sitemap/builder/sitemap-index.ts
@@ -73,9 +73,7 @@ async function buildSitemapIndexInternal(resolvers: NitroUrlResolvers, runtimeCo
     if (sitemapConfig.chunks || sitemapConfig._isChunking) {
       // Mark as chunking for later processing
       sitemapConfig._isChunking = true
-      sitemapConfig._chunkSize = typeof sitemapConfig.chunks === 'number'
-        ? sitemapConfig.chunks
-        : (sitemapConfig.chunkSize || defaultSitemapsChunkSize || 1000)
+      sitemapConfig._chunkSize = sitemapConfig.chunkSize || (typeof sitemapConfig.chunks === 'number' ? sitemapConfig.chunks : (defaultSitemapsChunkSize || 1000))
     }
     else {
       // Non-chunked sitemap


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

When both `chunkSize` and `chunks` (as a number) were set, `chunks` took precedence over the explicit `chunkSize` config. This fix corrects the precedence so `chunkSize` is checked first, matching user expectations.