### PR TITLE
fix: `zeroRuntime` prerender detection when no manual `nitro.prerender.routes`

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -43,7 +43,7 @@ import {
   normalizeLocales,
   splitPathForI18nLocales,
 } from './utils-internal/i18n'
-import { createNitroPromise, createPagesPromise, getNuxtModuleOptions, isNuxtGenerate, resolveNuxtContentVersion } from './utils-internal/kit'
+import { createNitroPromise, createPagesPromise, getNuxtModuleOptions, isNuxtGenerate, resolveNitroPreset, resolveNuxtContentVersion } from './utils-internal/kit'
 import { convertNuxtPagesToSitemapEntries, generateExtraRoutesFromNuxtConfig, resolveUrls } from './utils-internal/nuxtSitemap'
 
 declare global {
@@ -382,6 +382,11 @@ export default defineNuxtModule<ModuleOptions>({
     // check if the user provided route /api/_sitemap-urls exists
     const prerenderedRoutes = (nuxt.options.nitro.prerender?.routes || []) as string[]
     let prerenderSitemap = isNuxtGenerate() || includesSitemapRoot(config.sitemapName, prerenderedRoutes)
+
+    if (resolveNitroPreset() === 'vercel-edge') {
+      logger.warn('Runtime sitemaps are not supported on Vercel Edge, falling back to prerendering sitemaps.')
+      prerenderSitemap = true
+    }
 
     // zeroRuntime forces prerendering
     if (config.zeroRuntime && !prerenderSitemap) {
@@ -1071,7 +1076,7 @@ export async function readSourcesFromFilesystem() {
       handler: resolve(`${routesPath}/sitemap.xml`),
     })
 
-    setupPrerenderHandler({ runtimeConfig, logger, generateGlobalSources, generateChildSources })
+    setupPrerenderHandler({ runtimeConfig, logger, generateGlobalSources, generateChildSources, prerenderSitemap })
 
     // suggest zeroRuntime when no dynamic sources detected
     if (!config.zeroRuntime && !nuxt.options.dev && !nuxt.options._prepare) {

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -12,7 +12,7 @@ import { withSiteUrl } from 'nuxt-site-config/kit'
 import { dirname } from 'pathe'
 import { withBase } from 'ufo'
 import { splitForLocales } from './runtime/utils-pure'
-import { isNuxtGenerate, resolveNitroPreset } from './utils-internal/kit'
+import { isNuxtGenerate } from './utils-internal/kit'
 import { parseHtmlExtractSitemapMeta } from './utils/parseHtmlExtractSitemapMeta'
 
 function formatPrerenderRoute(route: PrerenderRoute) {
@@ -33,14 +33,8 @@ export function includesSitemapRoot(sitemapName: string, routes: string[]) {
 
 const NuxtRedirectHtmlRegex = /<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=([^"]+)"><\/head><\/html>/ // eslint-disable-line regexp/no-unused-capturing-group
 
-export function setupPrerenderHandler(_options: { runtimeConfig: ModuleRuntimeConfig, logger: ConsolaInstance, generateGlobalSources: () => Promise<any>, generateChildSources: () => Promise<any> }, nuxt: Nuxt = useNuxt()) {
-  const { runtimeConfig: options, logger, generateGlobalSources, generateChildSources } = _options
-  const prerenderedRoutes = (nuxt.options.nitro.prerender?.routes || []) as string[]
-  let prerenderSitemap = isNuxtGenerate() || includesSitemapRoot(options.sitemapName, prerenderedRoutes)
-  if (resolveNitroPreset() === 'vercel-edge') {
-    logger.warn('Runtime sitemaps are not supported on Vercel Edge, falling back to prerendering sitemaps.')
-    prerenderSitemap = true
-  }
+export function setupPrerenderHandler(_options: { runtimeConfig: ModuleRuntimeConfig, logger: ConsolaInstance, generateGlobalSources: () => Promise<any>, generateChildSources: () => Promise<any>, prerenderSitemap: boolean }, nuxt: Nuxt = useNuxt()) {
+  const { runtimeConfig: options, logger, generateGlobalSources, generateChildSources, prerenderSitemap } = _options
   nuxt.options.nitro.prerender = nuxt.options.nitro.prerender || {}
   nuxt.options.nitro.prerender.routes = nuxt.options.nitro.prerender.routes || []
   const shouldHookIntoPrerender = prerenderSitemap || (nuxt.options.nitro.prerender.routes.length && nuxt.options.nitro.prerender.crawlLinks)

--- a/test/e2e/single/issue-592.test.ts
+++ b/test/e2e/single/issue-592.test.ts
@@ -1,0 +1,43 @@
+import { existsSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
+import { buildNuxt, createResolver, loadNuxt } from '@nuxt/kit'
+import { describe, expect, it } from 'vitest'
+
+describe('issue #592: zeroRuntime should prerender sitemaps without manual nitro.prerender.routes', () => {
+  it('generates sitemap index and child sitemaps with zeroRuntime and i18n', async () => {
+    process.env.NODE_ENV = 'production'
+    process.env.NUXT_PUBLIC_SITE_URL = 'https://nuxtseo.com'
+    const { resolve } = createResolver(import.meta.url)
+    const rootDir = resolve('../../fixtures/issue-592')
+    const nuxt = await loadNuxt({
+      rootDir,
+      overrides: {
+        // SSR build, not nuxt generate: _generate is false, preset is node-server
+        _generate: false,
+        nitro: {
+          preset: 'node-server',
+          prerender: {
+            // no manual routes, zeroRuntime should handle it
+            crawlLinks: false,
+          },
+        },
+      },
+    })
+
+    await buildNuxt(nuxt)
+
+    await new Promise(resolve => setTimeout(resolve, 1000))
+
+    const outputDir = resolve(rootDir, '.output/public')
+
+    // sitemap_index.xml should exist
+    expect(existsSync(resolve(outputDir, 'sitemap_index.xml'))).toBe(true)
+    const sitemapIndex = await readFile(resolve(outputDir, 'sitemap_index.xml'), 'utf-8')
+    expect(sitemapIndex).toContain('__sitemap__/en-US.xml')
+    expect(sitemapIndex).toContain('__sitemap__/de-DE.xml')
+
+    // child sitemaps should exist
+    expect(existsSync(resolve(outputDir, '__sitemap__/en-US.xml'))).toBe(true)
+    expect(existsSync(resolve(outputDir, '__sitemap__/de-DE.xml'))).toBe(true)
+  }, 120000)
+})

--- a/test/fixtures/issue-592/nuxt.config.ts
+++ b/test/fixtures/issue-592/nuxt.config.ts
@@ -1,0 +1,37 @@
+import NuxtSitemap from '../../../src/module'
+
+export default defineNuxtConfig({
+  modules: [
+    NuxtSitemap,
+    '@nuxtjs/i18n',
+  ],
+
+  site: {
+    url: 'https://nuxtseo.com',
+  },
+
+  compatibilityDate: '2024-07-22',
+
+  i18n: {
+    baseUrl: 'https://nuxtseo.com',
+    detectBrowserLanguage: false,
+    defaultLocale: 'en',
+    strategy: 'prefix_except_default',
+    locales: [
+      {
+        code: 'en',
+        iso: 'en-US',
+      },
+      {
+        code: 'de',
+        iso: 'de-DE',
+      },
+    ],
+  },
+
+  sitemap: {
+    zeroRuntime: true,
+    autoLastmod: false,
+    credits: false,
+  },
+})

--- a/test/fixtures/issue-592/pages/index.vue
+++ b/test/fixtures/issue-592/pages/index.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    <h1>Home</h1>
+  </div>
+</template>


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #592

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`setupPrerenderHandler` re-derived `prerenderSitemap` by checking `nuxt.options.nitro.prerender.routes`, but `addPrerenderRoutes()` from `@nuxt/kit` only registers a Nitro hook and does not mutate that array. This caused the prerender handler to bail out early when `zeroRuntime: true` was set without manual routes, producing only a bare `/sitemap.xml` instead of the full sitemap index with child sitemaps.

The fix consolidates all `prerenderSitemap` decision logic (including the `vercel-edge` fallback) in `module.ts` and passes the resolved boolean directly into `setupPrerenderHandler`, eliminating the duplicate detection that was out of sync.

Includes a regression test that builds with `zeroRuntime: true`, i18n, and no manual prerender routes, then asserts the sitemap index and child locale sitemaps are generated.