### PR TITLE
fix: skip cache during prerender to prevent empty sitemap

### DIFF
--- a/src/runtime/server/sitemap/builder/sitemap-index.ts
+++ b/src/runtime/server/sitemap/builder/sitemap-index.ts
@@ -282,8 +282,10 @@ export function urlsToIndexXml(sitemaps: SitemapIndexEntry[], resolvers: NitroUr
 }
 
 export async function buildSitemapIndex(resolvers: NitroUrlResolvers, runtimeConfig: ModuleRuntimeConfig, nitro?: NitroApp) {
-  // Check if should use cached version
-  if (!import.meta.dev && typeof runtimeConfig.cacheMaxAgeSeconds === 'number' && runtimeConfig.cacheMaxAgeSeconds > 0 && resolvers.event) {
+  // Check if should use cached version.
+  // Skip caching during prerender: sources are written to disk by `prerender:done`, so
+  // an early crawl would otherwise poison the cache with an empty result.
+  if (!import.meta.dev && !import.meta.prerender && typeof runtimeConfig.cacheMaxAgeSeconds === 'number' && runtimeConfig.cacheMaxAgeSeconds > 0 && resolvers.event) {
     return buildSitemapIndexCached(resolvers.event, resolvers, runtimeConfig, nitro)
   }
   return buildSitemapIndexInternal(resolvers, runtimeConfig, nitro)

--- a/src/runtime/server/sitemap/nitro.ts
+++ b/src/runtime/server/sitemap/nitro.ts
@@ -185,8 +185,11 @@ const buildSitemapXmlCached = defineCachedFunction(
 export async function createSitemap(event: H3Event, definition: SitemapDefinition, runtimeConfig: ModuleRuntimeConfig) {
   const resolvers = useNitroUrlResolvers(event)
 
-  // Choose between cached or direct generation
-  const shouldCache = !import.meta.dev && typeof runtimeConfig.cacheMaxAgeSeconds === 'number' && runtimeConfig.cacheMaxAgeSeconds > 0
+  // Choose between cached or direct generation.
+  // Skip caching during prerender: the crawl may run before `prerender:done` has written
+  // `global-sources.json`, so an early empty result would poison the cache and be returned
+  // on the follow-up render, shipping an empty sitemap.
+  const shouldCache = !import.meta.dev && !import.meta.prerender && typeof runtimeConfig.cacheMaxAgeSeconds === 'number' && runtimeConfig.cacheMaxAgeSeconds > 0
   const xml = shouldCache
     ? await buildSitemapXmlCached(event, definition, resolvers, runtimeConfig)
     : await buildSitemapXml(event, definition, resolvers, runtimeConfig)

--- a/test/e2e/single/zero-runtime-build.test.ts
+++ b/test/e2e/single/zero-runtime-build.test.ts
@@ -40,6 +40,8 @@ describe('zeroRuntime', () => {
             </url>
             <url>
                 <loc>https://nuxtseo.com/about</loc>
+                <changefreq>daily</changefreq>
+                <priority>0.8</priority>
             </url>
             <url>
                 <loc>https://nuxtseo.com/crawled</loc>
@@ -49,6 +51,8 @@ describe('zeroRuntime', () => {
             </url>
             <url>
                 <loc>https://nuxtseo.com/sub/page</loc>
+                <changefreq>weekly</changefreq>
+                <priority>0.5</priority>
             </url>
         </urlset>"
       `)


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #603

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

With `zeroRuntime` enabled, cold builds could ship an empty sitemap. The prerender crawl fetches `/sitemap.xml` before `prerender:done` writes `global-sources.json`, and with `cacheMaxAgeSeconds > 0` that empty result poisons the cache and is returned on the follow-up render.

Skipping the cache layer during prerender (`import.meta.prerender`) in both `createSitemap` and `buildSitemapIndex` leaves `prerender:done` as the single authoritative writer.