### PR TITLE
perf: split static sitemap config into virtual module

### DIFF
--- a/benchmark/app/app.vue
+++ b/benchmark/app/app.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>bench</div>
+</template>

--- a/benchmark/bench.mjs
+++ b/benchmark/bench.mjs
@@ -1,0 +1,176 @@
+// Minimal throughput benchmark for @nuxtjs/sitemap
+// Usage:
+//   node benchmark/bench.mjs              # all variants
+//   BENCH_TARGET=/api/ping node benchmark/bench.mjs
+//
+// Each run gets its own .output dir so builds cannot leak between runs.
+// After each build we assert presence/absence of sitemap module artefacts.
+
+import { spawn } from 'node:child_process'
+import { once } from 'node:events'
+import { existsSync, readdirSync, readFileSync, rmSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { fileURLToPath } from 'node:url'
+import autocannon from 'autocannon'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const cwd = __dirname
+
+const TARGET = process.env.BENCH_TARGET || '/api/ping'
+const PORT = Number(process.env.BENCH_PORT || 3777)
+const DURATION = Number(process.env.BENCH_DURATION || 10)
+const CONNECTIONS = Number(process.env.BENCH_CONNECTIONS || 100)
+
+const SITEMAP_ARTEFACTS = [
+  'chunks/routes/sitemap.xml.mjs',
+  'chunks/virtual/global-sources.mjs',
+  'chunks/virtual/child-sources.mjs',
+]
+// strings that must NOT appear in baseline server bundle and SHOULD appear with sitemap on
+const SITEMAP_MARKERS = ['@nuxtjs/sitemap', 'useSitemapRuntimeConfig', '#sitemap-virtual']
+
+function isolate(label) {
+  const slug = label.replace(/[^a-z0-9]+/gi, '-').toLowerCase()
+  return {
+    nuxtDir: resolve(cwd, `.nuxt-${slug}`),
+    outDir: resolve(cwd, `.output-${slug}`),
+  }
+}
+
+function assertSitemapPresence({ outDir, expectSitemap, label }) {
+  const indexPath = resolve(outDir, 'server/index.mjs')
+  if (!existsSync(indexPath))
+    throw new Error(`[${label}] missing build: ${indexPath}`)
+
+  const presentArtefacts = SITEMAP_ARTEFACTS.filter(p => existsSync(resolve(outDir, 'server', p)))
+
+  const grepOut = []
+  const walker = (dir) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = resolve(dir, entry.name)
+      if (entry.isDirectory()) {
+        walker(full)
+      }
+      else if (entry.name.endsWith('.mjs')) {
+        const txt = readFileSync(full, 'utf8')
+        for (const m of SITEMAP_MARKERS) {
+          if (txt.includes(m))
+            grepOut.push(`${full.slice(outDir.length + 1)}: ${m}`)
+        }
+      }
+    }
+  }
+  walker(resolve(outDir, 'server'))
+
+  console.log(`[${label}] sitemap artefacts present: ${presentArtefacts.length} -> ${JSON.stringify(presentArtefacts)}`)
+  console.log(`[${label}] sitemap marker hits in bundle: ${grepOut.length}`)
+  if (grepOut.length)
+    console.log(grepOut.slice(0, 5).map(l => `  - ${l}`).join('\n'))
+
+  if (expectSitemap) {
+    if (grepOut.length === 0)
+      throw new Error(`[${label}] expected sitemap markers but found none`)
+  }
+  else {
+    if (presentArtefacts.length > 0)
+      throw new Error(`[${label}] BASELINE LEAK: sitemap artefacts present: ${JSON.stringify(presentArtefacts)}`)
+    if (grepOut.length > 0)
+      throw new Error(`[${label}] BASELINE LEAK: sitemap markers found in baseline bundle:\n${grepOut.slice(0, 10).join('\n')}`)
+  }
+}
+
+async function run(label, env, expectSitemap) {
+  const { nuxtDir, outDir } = isolate(label)
+  console.log(`\n=== ${label} ===`)
+  console.log(`env: ${JSON.stringify(env)}`)
+  console.log(`nuxtDir: ${nuxtDir}`)
+  console.log(`outDir:  ${outDir}`)
+
+  // wipe per-run dirs
+  for (const d of [nuxtDir, outDir]) rmSync(d, { recursive: true, force: true })
+
+  console.log('building...')
+  const slug = label.replace(/[^a-z0-9]+/gi, '-').toLowerCase()
+  const build = spawn(
+    'npx',
+    ['nuxt', 'build'],
+    {
+      cwd,
+      env: {
+        ...process.env,
+        ...env,
+        BENCH_SLUG: slug,
+        NUXT_TELEMETRY_DISABLED: '1',
+      },
+      stdio: 'inherit',
+    },
+  )
+  const [code] = await once(build, 'exit')
+  if (code !== 0)
+    throw new Error(`build failed (${code})`)
+
+  await assertSitemapPresence({ outDir, expectSitemap, label })
+
+  const server = spawn('node', [resolve(outDir, 'server/index.mjs')], {
+    cwd,
+    env: { ...process.env, PORT: String(PORT), HOST: '127.0.0.1' },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  let ready = false
+  server.stdout.on('data', (b) => {
+    const s = String(b)
+    process.stdout.write(`[server] ${s}`)
+    if (/Listening/.test(s))
+      ready = true
+  })
+  server.stderr.on('data', b => process.stderr.write(`[server] ${b}`))
+
+  for (let i = 0; i < 200 && !ready; i++) await sleep(100)
+  if (!ready) {
+    server.kill('SIGKILL')
+    throw new Error('server failed to start')
+  }
+  await sleep(200)
+
+  console.log(`benchmarking http://127.0.0.1:${PORT}${TARGET} for ${DURATION}s, ${CONNECTIONS} conns`)
+  const result = await autocannon({
+    url: `http://127.0.0.1:${PORT}${TARGET}`,
+    connections: CONNECTIONS,
+    duration: DURATION,
+  })
+
+  server.kill('SIGTERM')
+  await once(server, 'exit').catch(() => {})
+
+  return {
+    label,
+    rps: result.requests.average,
+    rpsMin: result.requests.min,
+    rpsMax: result.requests.max,
+    latencyAvg: result.latency.average,
+    latencyP99: result.latency.p99,
+    errors: result.errors,
+    non2xx: result.non2xx,
+  }
+}
+
+const runs = []
+runs.push(await run('baseline-no-sitemap', { BENCH_SITEMAP: '0' }, false))
+runs.push(await run('sitemap-default', { BENCH_SITEMAP: '1', BENCH_WARMUP: '1' }, true))
+runs.push(await run('sitemap-no-warmup', { BENCH_SITEMAP: '1', BENCH_WARMUP: '0' }, true))
+runs.push(await run('sitemap-no-xsl', { BENCH_SITEMAP: '1', BENCH_WARMUP: '0', BENCH_XSL: '0' }, true))
+runs.push(await run('sitemap-zero-runtime', { BENCH_SITEMAP: '1', BENCH_WARMUP: '0', BENCH_ZERO: '1' }, true))
+runs.push(await run('sitemap-rc-stub', { BENCH_SITEMAP: '1', BENCH_WARMUP: '0', BENCH_RC_STUB: '1' }, true))
+
+console.log('\n=== summary ===')
+console.table(runs.map(r => ({
+  'label': r.label,
+  'req/s avg': r.rps.toFixed(0),
+  'req/s min': r.rpsMin.toFixed(0),
+  'req/s max': r.rpsMax.toFixed(0),
+  'lat avg ms': r.latencyAvg.toFixed(2),
+  'lat p99 ms': r.latencyP99.toFixed(2),
+  'errors': r.errors,
+  'non2xx': r.non2xx,
+})))

--- a/benchmark/nuxt.config.ts
+++ b/benchmark/nuxt.config.ts
@@ -1,0 +1,48 @@
+const enableSitemap = process.env.BENCH_SITEMAP === '1'
+const enableWarmUp = process.env.BENCH_WARMUP !== '0'
+const enableXsl = process.env.BENCH_XSL !== '0'
+const zeroRuntime = process.env.BENCH_ZERO === '1'
+const slug = process.env.BENCH_SLUG || 'default'
+
+console.log(`[bench/nuxt.config] sitemap=${enableSitemap} warm=${enableWarmUp} xsl=${enableXsl} zero=${zeroRuntime} slug=${slug}`)
+
+export default defineNuxtConfig({
+  modules: [
+    ...(enableSitemap ? ['../src/module'] : []),
+    (_options: any, nuxt: any) => {
+      nuxt.hook('modules:done', () => {
+        const names = nuxt.options._installedModules.map((m: any) => m?.meta?.name || m?.entryPath || '?')
+        console.log(`[bench] installed modules (${names.length}): ${JSON.stringify(names)}`)
+      })
+    },
+  ] as any,
+
+  site: {
+    url: 'https://example.com',
+  },
+
+  sitemap: {
+    enabled: enableSitemap,
+    excludeAppSources: true,
+    debug: false,
+    sitemapsPathPrefix: '/',
+    discoverImages: false,
+    discoverVideos: false,
+    experimentalWarmUp: enableWarmUp,
+    xsl: enableXsl ? '/__sitemap__/style.xsl' : false,
+    zeroRuntime,
+    autoI18n: false,
+    cacheMaxAgeSeconds: 36000,
+  },
+
+  compatibilityDate: '2025-01-01',
+
+  buildDir: `.nuxt-${slug}`,
+
+  nitro: {
+    preset: 'node-server',
+    output: {
+      dir: `.output-${slug}`,
+    },
+  },
+})

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "sitemap-benchmark",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "bench": "node bench.mjs"
+  },
+  "dependencies": {
+    "@nuxtjs/sitemap": "workspace:*",
+    "autocannon": "catalog:",
+    "nuxt": "catalog:",
+    "vue": "catalog:"
+  }
+}

--- a/benchmark/server/api/ping.get.ts
+++ b/benchmark/server/api/ping.get.ts
@@ -1,0 +1,3 @@
+import { defineEventHandler } from 'h3'
+
+export default defineEventHandler(() => ({ ok: true }))

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,6 +9,7 @@ export default antfu(
       'test/fixtures/**',
       'playground/**',
       'docs/**',
+      'benchmark/**',
     ],
     rules: {
       'no-use-before-define': 'off',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ catalogs:
     '@vueuse/core':
       specifier: ^14.2.1
       version: 14.2.1
+    autocannon:
+      specifier: ^8.0.0
+      version: 8.0.0
     better-sqlite3:
       specifier: ^12.9.0
       version: 12.9.0
@@ -268,6 +271,21 @@ importers:
         specifier: 'catalog:'
         version: 4.3.6
 
+  benchmark:
+    dependencies:
+      '@nuxtjs/sitemap':
+        specifier: workspace:*
+        version: link:..
+      autocannon:
+        specifier: 'catalog:'
+        version: 8.0.0
+      nuxt:
+        specifier: 'catalog:'
+        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.4)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.32)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(esbuild@0.27.4)(eslint@10.2.0(jiti@2.6.1))(ioredis@5.9.2)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.0.0-rc.15)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-rc.15)(rollup@4.60.0))(rollup@4.60.0)(terser@5.46.0)(typescript@6.0.2)(vite@8.0.8(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@6.0.2))(yaml@2.8.3)
+      vue:
+        specifier: 'catalog:'
+        version: 3.5.32(typescript@6.0.2)
+
   devtools:
     devDependencies:
       '@iconify-json/carbon':
@@ -385,6 +403,9 @@ packages:
   '@arethetypeswrong/core@0.18.2':
     resolution: {integrity: sha512-GiwTmBFOU1/+UVNqqCGzFJYfBXEytUkiI+iRZ6Qx7KmUVtLm00sYySkfe203C9QtPG11yOz1ZaMek8dT/xnlgg==}
     engines: {node: '>=20'}
+
+  '@assemblyscript/loader@0.19.23':
+    resolution: {integrity: sha512-ulkCYfFbYj01ie1MDOyxv2F6SpRN1TOj7fQxbP07D6HmeR+gr2JLSmINKjga2emB+b1L2KGrFKBTc+e00p54nw==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -1170,6 +1191,9 @@ packages:
     resolution: {integrity: sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@minimistjs/subarg@1.0.0':
+    resolution: {integrity: sha512-Q/ONBiM2zNeYUy0mVSO44mWWKYM3UHuEK43PKIOzJCbvUnPoMH1K+gk3cf1kgnCVJFlWmddahQQCmrmBGlk9jQ==}
 
   '@miyaneee/rollup-plugin-json5@1.2.0':
     resolution: {integrity: sha512-JjTIaXZp9WzhUHpElrqPnl1AzBi/rvRs065F71+aTmlqvTMVkdbjZ8vfFl4nRlgJy+TPBw69ZK4pwFdmOAt4aA==}
@@ -3546,6 +3570,13 @@ packages:
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  autocannon@8.0.0:
+    resolution: {integrity: sha512-fMMcWc2JPFcUaqHeR6+PbmEpTxCrPZyBUM95oG4w3ngJ8NfBNas/ZXA+pTHXLqJ0UlFVTcy05GC25WxKx/M20A==}
+    hasBin: true
+
   autoprefixer@10.4.27:
     resolution: {integrity: sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==}
     engines: {node: ^10 || ^12 || >=14}
@@ -3723,6 +3754,9 @@ packages:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
     engines: {node: '>=10'}
 
+  char-spinner@1.0.1:
+    resolution: {integrity: sha512-acv43vqJ0+N0rD+Uw3pDHSxP30FHrywu2NO6/wBaHChJIizpDeBUd6NjqhNhy9LGaEAhZAXn46QzmlAvIWd16g==}
+
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
 
@@ -3805,11 +3839,19 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  color-support@1.1.3:
+    resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
+    hasBin: true
+
   colord@2.9.3:
     resolution: {integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==}
 
   colortranslator@5.0.0:
     resolution: {integrity: sha512-Z3UPUKasUVDFCDYAjP2fmlVRf1jFHJv1izAmPjiOa0OCIw1W7iC8PZ2GsoDa8uZv+mKyWopxxStT9q05+27h7w==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
@@ -3893,6 +3935,9 @@ packages:
   croner@9.1.0:
     resolution: {integrity: sha512-p9nwwR4qyT5W996vBZhdvBCnMhicY5ytZkR4D1Xj0wuTDEiMnjwR57Q3RXYY/s0EpX6Ay3vgIcfaR+ewGHsi+g==}
     engines: {node: '>=18.0'}
+
+  cross-argv@2.0.0:
+    resolution: {integrity: sha512-YIaY9TR5Nxeb8SMdtrU8asWVM4jqJDNDYlKV21LxtYcfNJhp1kEsgSa6qXwXgzN0WQWGODps0+TlGp2xQSHwOg==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -4027,6 +4072,10 @@ packages:
 
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   denque@2.1.0:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
@@ -4226,6 +4275,10 @@ packages:
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
   esbuild@0.25.12:
@@ -4639,6 +4692,10 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
   format@0.2.2:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
     engines: {node: '>=0.4.x'}
@@ -4807,6 +4864,9 @@ packages:
     resolution: {integrity: sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==}
     engines: {node: '>=20.0.0'}
 
+  has-async-hooks@1.0.0:
+    resolution: {integrity: sha512-YF0VPGjkxr7AyyQQNykX8zK4PvtEDsUJAPqwu06UFz1lb6EvI53sPh5H1kWxg8NXI5LsfRCZ8uX9NkYDZBb/mw==}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -4880,6 +4940,13 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
+  hdr-histogram-js@3.0.1:
+    resolution: {integrity: sha512-l3GSdZL1Jr1C0kyb461tUjEdrRPZr8Qry7jByltf5JGrA0xvqOSrxRBfcrJqqV/AMEtqqhHhC6w8HW0gn76tRQ==}
+    engines: {node: '>=14'}
+
+  hdr-histogram-percentiles-obj@3.0.0:
+    resolution: {integrity: sha512-7kIufnBqdsBGcSZLPJwqHT3yhk1QTsSlFsVD3kx5ixH/AlgBs9yM1q6DPhXZ8f8gtdqgh7N7/5btRLpQsS2gHw==}
+
   hey-listen@1.0.8:
     resolution: {integrity: sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==}
 
@@ -4905,6 +4972,9 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
+  http-parser-js@0.5.10:
+    resolution: {integrity: sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==}
+
   http-shutdown@1.2.2:
     resolution: {integrity: sha512-S9wWkJ/VSY9/k4qcjG318bqJNruzE4HySUhFYknwmu6LBP97KLLfwNf+n4V1BHurvFNkSKLFnK/RsuUnRTf9Vw==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
@@ -4923,6 +4993,9 @@ packages:
   human-signals@8.0.1:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
     engines: {node: '>=18.18.0'}
+
+  hyperid@3.3.0:
+    resolution: {integrity: sha512-7qhCVT4MJIoEsNcbhglhdmBKb09QtcmJNiIQGq7js/Khf5FtQQ9bzcAuloeqBeee7XD7JqDeve9KNlQya5tSGQ==}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -5304,8 +5377,17 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.chunk@4.2.0:
+    resolution: {integrity: sha512-ZzydJKfUHJwHa+hF5X66zLFCBrWn5GeF28OHEr4WVWtNDXlQ/IjWKPBiikqKo2ne0+v6JgCgJ0GzJp8k8bHC7w==}
+
+  lodash.clonedeep@4.5.0:
+    resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
+
   lodash.defaults@4.2.0:
     resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
+  lodash.flatten@4.4.0:
+    resolution: {integrity: sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==}
 
   lodash.isarguments@3.1.0:
     resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
@@ -5347,6 +5429,9 @@ packages:
 
   magicast@0.5.2:
     resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
+
+  manage-path@2.0.0:
+    resolution: {integrity: sha512-NJhyB+PJYTpxhxZJ3lecIGgh4kwIY2RAh44XvAz9UlqthlQwtPBf62uBVR8XaD8CRuSjQ6TnZH2lNJkbLPZM2A==}
 
   markdown-it@14.1.1:
     resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
@@ -5527,8 +5612,16 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
   mime-types@3.0.2:
@@ -5808,6 +5901,10 @@ packages:
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
+
+  on-net-listen@1.1.2:
+    resolution: {integrity: sha512-y1HRYy8s/RlcBvDUwKXSmkODMdx4KSuIvloCnQYJ2LdBBC1asY4HtfhXwe3UWknLakATZDnbzht2Ijw3M1EqFg==}
+    engines: {node: '>=9.4.0 || ^8.9.4'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -6186,6 +6283,10 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  pretty-bytes@5.6.0:
+    resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}
+    engines: {node: '>=6'}
+
   pretty-bytes@7.1.0:
     resolution: {integrity: sha512-nODzvTiYVRGRqAOvE84Vk5JDPyyxsVk0/fbA/bq7RqlnhksGpset09XTxbpvLTIjoaF7K8Z8DG8yHtKGTPSYRw==}
     engines: {node: '>=20'}
@@ -6200,6 +6301,10 @@ packages:
   process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
+
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
@@ -6391,6 +6496,9 @@ packages:
   rehype-sort-attributes@5.0.1:
     resolution: {integrity: sha512-Bxo+AKUIELcnnAZwJDt5zUDDRpt4uzhfz9d0PVGhcxYWsbFj5Cv35xuWxu5r1LeYNFNhgGqsr9Q2QiIOM/Qctg==}
 
+  reinterval@1.1.0:
+    resolution: {integrity: sha512-QIRet3SYrGp0HUHO88jVskiG6seqUGC5iAG7AwI/BV4ypGcuqk9Du6YQBUOUqm9c8pw1eyLoIaONifRua1lsEQ==}
+
   reka-ui@2.9.3:
     resolution: {integrity: sha512-C9lCVxsSC7uYD0Nbgik1+14FNndHNprZmf0zGQt0ZDYIt5KxXV3zD0hEqNcfRUsEEJvVmoRsUkJnASBVBeaaUw==}
     peerDependencies:
@@ -6434,6 +6542,9 @@ packages:
     resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
     engines: {node: '>= 0.4'}
     hasBin: true
+
+  retimer@3.0.0:
+    resolution: {integrity: sha512-WKE0j11Pa0ZJI5YIk0nflGI7SQsfl2ljihVy7ogh7DeQSeYAUi0ubZ/yEueGtDfUPk6GH5LRw1hBdLq4IwUBWA==}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -6806,6 +6917,10 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  timestring@6.0.0:
+    resolution: {integrity: sha512-wMctrWD2HZZLuIlchlkE2dfXJh7J2KDI9Dwl+2abPYg0mswQHfOAyQW3jJg1pY5VfttSINZuKcXoB3FGypVklA==}
+    engines: {node: '>=8'}
+
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
@@ -7145,6 +7260,13 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid-parse@1.1.0:
+    resolution: {integrity: sha512-OdmXxA8rDsQ7YpNVbKSJkNzTw2I+S5WsbMDnCtIWSQaosNAcWtFuI/YK1TjzUI6nbkgiqEyh8gWngfcv8Asd9A==}
+
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    hasBin: true
 
   validate-npm-package-name@5.0.1:
     resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
@@ -7664,6 +7786,8 @@ snapshots:
       semver: 7.7.4
       typescript: 5.6.1-rc
       validate-npm-package-name: 5.0.1
+
+  '@assemblyscript/loader@0.19.23': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -8404,6 +8528,10 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  '@minimistjs/subarg@1.0.0':
+    dependencies:
+      minimist: 1.2.8
 
   '@miyaneee/rollup-plugin-json5@1.2.0(rollup@4.60.0)':
     dependencies:
@@ -10326,8 +10454,8 @@ snapshots:
 
   '@typescript-eslint/project-service@8.57.1(typescript@6.0.2)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.58.0(typescript@6.0.2)
-      '@typescript-eslint/types': 8.58.0
+      '@typescript-eslint/tsconfig-utils': 8.58.2(typescript@6.0.2)
+      '@typescript-eslint/types': 8.58.2
       debug: 4.4.3
       typescript: 6.0.2
     transitivePeerDependencies:
@@ -10972,6 +11100,34 @@ snapshots:
 
   async@3.2.6: {}
 
+  asynckit@0.4.0: {}
+
+  autocannon@8.0.0:
+    dependencies:
+      '@minimistjs/subarg': 1.0.0
+      chalk: 4.1.2
+      char-spinner: 1.0.1
+      cli-table3: 0.6.5
+      color-support: 1.1.3
+      cross-argv: 2.0.0
+      form-data: 4.0.5
+      has-async-hooks: 1.0.0
+      hdr-histogram-js: 3.0.1
+      hdr-histogram-percentiles-obj: 3.0.0
+      http-parser-js: 0.5.10
+      hyperid: 3.3.0
+      lodash.chunk: 4.2.0
+      lodash.clonedeep: 4.5.0
+      lodash.flatten: 4.4.0
+      manage-path: 2.0.0
+      on-net-listen: 1.1.2
+      pretty-bytes: 5.6.0
+      progress: 2.0.3
+      reinterval: 1.1.0
+      retimer: 3.0.0
+      semver: 7.7.4
+      timestring: 6.0.0
+
   autoprefixer@10.4.27(postcss@8.5.8):
     dependencies:
       browserslist: 4.28.1
@@ -11157,6 +11313,8 @@ snapshots:
 
   char-regex@1.0.2: {}
 
+  char-spinner@1.0.1: {}
+
   character-entities-html4@2.1.0: {}
 
   character-entities-legacy@3.0.0: {}
@@ -11246,9 +11404,15 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  color-support@1.1.3: {}
+
   colord@2.9.3: {}
 
   colortranslator@5.0.0: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
 
   comma-separated-tokens@2.0.3: {}
 
@@ -11311,6 +11475,8 @@ snapshots:
   crelt@1.0.6: {}
 
   croner@9.1.0: {}
+
+  cross-argv@2.0.0: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -11440,6 +11606,8 @@ snapshots:
   defu@6.1.4: {}
 
   defu@6.1.7: {}
+
+  delayed-stream@1.0.0: {}
 
   denque@2.1.0: {}
 
@@ -11605,6 +11773,13 @@ snapshots:
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -12187,6 +12362,14 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
   format@0.2.2: {}
 
   fraction.js@5.3.4: {}
@@ -12371,6 +12554,8 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  has-async-hooks@1.0.0: {}
+
   has-flag@4.0.0: {}
 
   has-property-descriptors@1.0.2:
@@ -12529,6 +12714,14 @@ snapshots:
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
 
+  hdr-histogram-js@3.0.1:
+    dependencies:
+      '@assemblyscript/loader': 0.19.23
+      base64-js: 1.5.1
+      pako: 1.0.11
+
+  hdr-histogram-percentiles-obj@3.0.0: {}
+
   hey-listen@1.0.8: {}
 
   highlight.js@10.7.3: {}
@@ -12551,6 +12744,8 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  http-parser-js@0.5.10: {}
+
   http-shutdown@1.2.2: {}
 
   https-proxy-agent@7.0.6:
@@ -12565,6 +12760,12 @@ snapshots:
   human-signals@5.0.0: {}
 
   human-signals@8.0.1: {}
+
+  hyperid@3.3.0:
+    dependencies:
+      buffer: 5.7.1
+      uuid: 8.3.2
+      uuid-parse: 1.1.0
 
   ieee754@1.2.1: {}
 
@@ -12902,7 +13103,13 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.chunk@4.2.0: {}
+
+  lodash.clonedeep@4.5.0: {}
+
   lodash.defaults@4.2.0: {}
+
+  lodash.flatten@4.4.0: {}
 
   lodash.isarguments@3.1.0: {}
 
@@ -12947,6 +13154,8 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       source-map-js: 1.2.1
+
+  manage-path@2.0.0: {}
 
   markdown-it@14.1.1:
     dependencies:
@@ -13336,7 +13545,13 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
+  mime-db@1.52.0: {}
+
   mime-db@1.54.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   mime-types@3.0.2:
     dependencies:
@@ -13917,6 +14132,8 @@ snapshots:
     dependencies:
       ee-first: 1.1.1
 
+  on-net-listen@1.1.2: {}
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -14389,6 +14606,8 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  pretty-bytes@5.6.0: {}
+
   pretty-bytes@7.1.0: {}
 
   pretty-ms@9.3.0:
@@ -14398,6 +14617,8 @@ snapshots:
   process-nextick-args@2.0.1: {}
 
   process@0.11.10: {}
+
+  progress@2.0.3: {}
 
   property-information@7.1.0: {}
 
@@ -14667,6 +14888,8 @@ snapshots:
       '@types/hast': 3.0.4
       unist-util-visit: 5.1.0
 
+  reinterval@1.1.0: {}
+
   reka-ui@2.9.3(vue@3.5.32(typescript@6.0.2)):
     dependencies:
       '@floating-ui/dom': 1.7.6
@@ -14761,6 +14984,8 @@ snapshots:
       is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  retimer@3.0.0: {}
 
   reusify@1.1.0: {}
 
@@ -15198,6 +15423,8 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  timestring@6.0.0: {}
+
   tiny-inflate@1.0.3: {}
 
   tiny-invariant@1.3.3: {}
@@ -15556,6 +15783,10 @@ snapshots:
       punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
+
+  uuid-parse@1.1.0: {}
+
+  uuid@8.3.2: {}
 
   validate-npm-package-name@5.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,7 @@ packages:
   - devtools
   - test/fixtures/**
   - playground
+  - benchmark
   - '!examples/**'
 overrides:
   '@vitejs/plugin-vue': ^6.0.6
@@ -30,6 +31,7 @@ catalog:
   '@nuxtjs/robots': ^6.0.7
   '@vue/test-utils': ^2.4.6
   '@vueuse/core': ^14.2.1
+  autocannon: ^8.0.0
   better-sqlite3: ^12.9.0
   bumpp: ^11.0.1
   consola: ^3.4.2

--- a/src/module.ts
+++ b/src/module.ts
@@ -410,37 +410,32 @@ export default defineNuxtModule<ModuleOptions>({
         'X-Sitemap-Prerendered': new Date().toISOString(),
       }
     }
-    if (config.xsl) {
-      nuxt.options.nitro.routeRules[config.xsl] = {
-        headers: {
-          'Content-Type': 'application/xslt+xml',
-        },
-      }
-    }
+    // The xsl handler sets its own Content-Type header, so no routeRule needed for it.
+    // Only register the per-sitemap routeRules entries when they actually carry content.
+    // An empty {} rule still gets matched on every request via the routeRules matcher,
+    // adding measurable overhead on unrelated routes for no benefit.
+    const hasRouteRuleContent = Object.keys(routeRules).length > 0
     if (usingMultiSitemaps) {
       nuxt.options.nitro.routeRules['/sitemap.xml'] = { redirect: withBase('/sitemap_index.xml', nuxt.options.app.baseURL) }
-      nuxt.options.nitro.routeRules['/sitemap_index.xml'] = routeRules
-      if (typeof config.sitemaps === 'object') {
-        for (const k in config.sitemaps) {
-          if (k === 'index')
-            continue
-          // Apply route rules to the base sitemap
-          nuxt.options.nitro.routeRules[joinURL(config.sitemapsPathPrefix || '', `/${k}.xml`)] = routeRules
+      if (hasRouteRuleContent) {
+        nuxt.options.nitro.routeRules['/sitemap_index.xml'] = routeRules
+        if (typeof config.sitemaps === 'object') {
+          for (const k in config.sitemaps) {
+            if (k === 'index')
+              continue
+            nuxt.options.nitro.routeRules[joinURL(config.sitemapsPathPrefix || '', `/${k}.xml`)] = routeRules
 
-          // Apply route rules to chunked sitemaps if enabled
-          const sitemapConfig = config.sitemaps[k]!
-          if (sitemapConfig.chunks) {
-            // Support chunked sitemap names (e.g., posts-0.xml, posts-1.xml, etc.)
-            nuxt.options.nitro.routeRules[joinURL(config.sitemapsPathPrefix || '', `/${k}-*.xml`)] = routeRules
+            const sitemapConfig = config.sitemaps[k]!
+            if (sitemapConfig.chunks)
+              nuxt.options.nitro.routeRules[joinURL(config.sitemapsPathPrefix || '', `/${k}-*.xml`)] = routeRules
           }
         }
-      }
-      else {
-        // Auto-chunking: support the chunked generated sitemap names (0.xml, 1.xml, etc.)
-        nuxt.options.nitro.routeRules[joinURL(config.sitemapsPathPrefix || '', `/[0-9]+.xml`)] = routeRules
+        else {
+          nuxt.options.nitro.routeRules[joinURL(config.sitemapsPathPrefix || '', `/[0-9]+.xml`)] = routeRules
+        }
       }
     }
-    else {
+    else if (hasRouteRuleContent) {
       nuxt.options.nitro.routeRules[`/${config.sitemapName}`] = routeRules
     }
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -814,8 +814,23 @@ export default defineNuxtModule<ModuleOptions>({
       runtimeConfig.autoI18n = resolvedAutoI18n
     if (hasDisabledAutoI18n)
       runtimeConfig.hasDisabledAutoI18n = true
+
+    // Split into a small dynamic slice (kept in runtimeConfig for env-var overrides)
+    // and a large static slice (emitted as a virtual module). Nitro deep-clones the
+    // entire runtimeConfig on the first useRuntimeConfig(event) per request, so anything
+    // sitting in there is per-request overhead for every route in the app, not just sitemap routes.
+    const dynamicRuntimeConfig = {
+      cacheMaxAgeSeconds: runtimeConfig.cacheMaxAgeSeconds,
+      debug: runtimeConfig.debug,
+    }
+    const { cacheMaxAgeSeconds: _c, debug: _d, ...staticRuntimeConfig } = runtimeConfig
     // @ts-expect-error untyped
-    nuxt.options.runtimeConfig.sitemap = runtimeConfig
+    nuxt.options.runtimeConfig.sitemap = dynamicRuntimeConfig
+    nuxt.hook('nitro:config', (nitroConfig) => {
+      nitroConfig.virtual = nitroConfig.virtual || {}
+      nitroConfig.virtual['#sitemap-virtual/static-config.mjs']
+        = `export default ${JSON.stringify(staticRuntimeConfig)}`
+    })
 
     // debug endpoints - skip in production zeroRuntime as they pull in full sitemap code
     if ((config.debug || nuxt.options.dev) && !(config.zeroRuntime && !nuxt.options.dev)) {

--- a/src/runtime/server/utils.ts
+++ b/src/runtime/server/utils.ts
@@ -1,5 +1,7 @@
 import type { H3Event } from 'h3'
 import type { ModuleRuntimeConfig } from '../types'
+// @ts-expect-error virtual module
+import staticConfig from '#sitemap-virtual/static-config.mjs'
 import { useRuntimeConfig } from 'nitropack/runtime'
 import { normalizeRuntimeFilters } from '../utils-pure'
 
@@ -16,15 +18,15 @@ export function xmlEscape(str: string): string {
 }
 
 export function useSitemapRuntimeConfig(e?: H3Event): ModuleRuntimeConfig {
-  // we need to clone with this hack so that we can write to the config
-  const clone = JSON.parse(JSON.stringify(useRuntimeConfig(e).sitemap)) as any as ModuleRuntimeConfig
-  // normalize the filters for runtime
+  // Static fields live in a virtual module; only env-overridable fields go through runtimeConfig.
+  // we still need to clone so callers can mutate without affecting the shared module-scope copy
+  const clone = JSON.parse(JSON.stringify(staticConfig)) as ModuleRuntimeConfig
   for (const k in clone.sitemaps) {
     const sitemap = clone.sitemaps[k]!
     sitemap.include = normalizeRuntimeFilters(sitemap.include)
     sitemap.exclude = normalizeRuntimeFilters(sitemap.exclude)
     clone.sitemaps[k] = sitemap
   }
-  // avoid mutation
+  Object.assign(clone, useRuntimeConfig(e).sitemap)
   return Object.freeze(clone)
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "test/**",
     "playground",
     "examples",
+    "benchmark",
     "src/runtime/server/routes/__sitemap__/nuxt-content-urls-v3.ts"
   ]
 }


### PR DESCRIPTION
### 🔗 Linked issue

Closes nuxt-modules/sitemap#542 (referenced in https://github.com/harlan-zw/nuxt-seo/discussions/542)

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Reported in harlan-zw/nuxt-seo#542: enabling `@nuxtjs/sitemap` measurably degrades request throughput across the entire app, not just on `/sitemap.xml`. Locally reproduced as a ~30% drop on `/api/ping` autocannon runs.

**Root cause.** Nitro deep-clones the entire `runtimeConfig` on the first `useRuntimeConfig(event)` call per request. `nuxt-site-config` (transitively installed by sitemap) registers a `middleware: true` init handler that calls `useRuntimeConfig(e)` on every request, so every route in the app pays the clone+`applyEnv` cost over the sitemap config blob.

**Fix.** Split `runtimeConfig.sitemap`:
- The large static slice (`sitemaps`, `xslColumns`, `xslTips`, `version`, all the build-time flags) moves into a virtual module `#sitemap-virtual/static-config.mjs` that's only imported by sitemap handlers.
- Only env-overridable fields (`cacheMaxAgeSeconds`, `debug`) stay in `runtimeConfig.sitemap` so `NUXT_SITEMAP_*` env vars still work.

Also drops two redundant routeRules in a follow-up commit:
- The xsl `Content-Type` routeRule (the handler already sets the header itself).
- The empty `{}` rule on the single-sitemap path (was matched against on every request via the routeRules matcher for no benefit).

Adds a `benchmark/` workspace with autocannon-driven throughput tests across sitemap on/off and `zeroRuntime` variants. Each variant builds into its own `.output` dir and asserts module artefact presence to prevent baseline leaks.

### 📈 Results (autocannon, /api/ping, 100 conns, 20s)

| | rps | vs baseline |
|---|---|---|
| baseline (no sitemap) | 11037 | — |
| sitemap (before) | 6296 | -32% |
| sitemap (after) | 10875 | **-1.5%** (within noise) |