### PR TITLE
perf: lazy load `fast-xml-parser` in parseSitemapIndex

### DIFF
--- a/src/runtime/server/routes/__sitemap__/debug-production.ts
+++ b/src/runtime/server/routes/__sitemap__/debug-production.ts
@@ -59,7 +59,7 @@ export default defineEventHandler(async (e): Promise<ProductionDebugResponse | R
     return { url: sitemapUrl, isIndex: false, sitemaps: [], warnings: [], error: `Failed to fetch sitemap: ${xml.message}` }
 
   if (isSitemapIndex(xml)) {
-    const { entries, warnings } = parseSitemapIndex(xml)
+    const { entries, warnings } = await parseSitemapIndex(xml)
     const sitemaps: ProductionSitemapEntry[] = await Promise.all(
       entries.map(async (entry) => {
         const childXml = await fetchXml(entry.loc).catch((err: Error) => err)

--- a/src/utils/parseSitemapIndex.ts
+++ b/src/utils/parseSitemapIndex.ts
@@ -1,5 +1,4 @@
 import type { SitemapWarning } from './parseSitemapXml'
-import { XMLParser } from 'fast-xml-parser'
 
 export interface SitemapIndexEntry {
   loc: string
@@ -24,20 +23,20 @@ interface ParsedRoot {
   sitemapindex?: ParsedSitemapIndex
 }
 
-const parser = new XMLParser({
-  isArray: (tagName: string) => tagName === 'sitemap',
-  removeNSPrefix: true,
-  trimValues: true,
-})
-
 function isValidUrl(value: string): boolean {
   return URL.canParse(value)
 }
 
-export function parseSitemapIndex(xml: string): SitemapIndexParseResult {
+export async function parseSitemapIndex(xml: string): Promise<SitemapIndexParseResult> {
   if (!xml)
     throw new Error('Empty XML input provided')
 
+  const { XMLParser } = await import('fast-xml-parser')
+  const parser = new XMLParser({
+    isArray: (tagName: string) => tagName === 'sitemap',
+    removeNSPrefix: true,
+    trimValues: true,
+  })
   const parsed = parser.parse(xml) as ParsedRoot
 
   if (parsed?.sitemapindex === undefined)

--- a/test/unit/sitemapIndex.test.ts
+++ b/test/unit/sitemapIndex.test.ts
@@ -24,7 +24,7 @@ describe('isSitemapIndex', () => {
 })
 
 describe('parseSitemapIndex', () => {
-  it('parses basic sitemap index', () => {
+  it('parses basic sitemap index', async () => {
     const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <sitemap>
@@ -35,7 +35,7 @@ describe('parseSitemapIndex', () => {
   </sitemap>
 </sitemapindex>`
 
-    const { entries, warnings } = parseSitemapIndex(xml)
+    const { entries, warnings } = await parseSitemapIndex(xml)
     expect(entries).toEqual([
       { loc: 'https://example.com/sitemap-1.xml' },
       { loc: 'https://example.com/sitemap-2.xml' },
@@ -43,7 +43,7 @@ describe('parseSitemapIndex', () => {
     expect(warnings).toEqual([])
   })
 
-  it('parses sitemap index with lastmod', () => {
+  it('parses sitemap index with lastmod', async () => {
     const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <sitemap>
@@ -52,14 +52,14 @@ describe('parseSitemapIndex', () => {
   </sitemap>
 </sitemapindex>`
 
-    const { entries, warnings } = parseSitemapIndex(xml)
+    const { entries, warnings } = await parseSitemapIndex(xml)
     expect(entries).toEqual([
       { loc: 'https://example.com/sitemap-1.xml', lastmod: '2024-01-15' },
     ])
     expect(warnings).toEqual([])
   })
 
-  it('handles single sitemap entry', () => {
+  it('handles single sitemap entry', async () => {
     const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <sitemap>
@@ -67,22 +67,22 @@ describe('parseSitemapIndex', () => {
   </sitemap>
 </sitemapindex>`
 
-    const { entries } = parseSitemapIndex(xml)
+    const { entries } = await parseSitemapIndex(xml)
     expect(entries).toHaveLength(1)
     expect(entries[0].loc).toBe('https://example.com/sitemap.xml')
   })
 
-  it('returns empty array for empty sitemapindex', () => {
+  it('returns empty array for empty sitemapindex', async () => {
     const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 </sitemapindex>`
 
-    const { entries, warnings } = parseSitemapIndex(xml)
+    const { entries, warnings } = await parseSitemapIndex(xml)
     expect(entries).toEqual([])
     expect(warnings).toEqual([])
   })
 
-  it('warns on entries without loc', () => {
+  it('warns on entries without loc', async () => {
     const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <sitemap>
@@ -93,7 +93,7 @@ describe('parseSitemapIndex', () => {
   </sitemap>
 </sitemapindex>`
 
-    const { entries, warnings } = parseSitemapIndex(xml)
+    const { entries, warnings } = await parseSitemapIndex(xml)
     expect(entries).toEqual([
       { loc: 'https://example.com/valid.xml' },
     ])
@@ -101,7 +101,7 @@ describe('parseSitemapIndex', () => {
     expect(warnings[0].message).toBe('Sitemap entry missing required loc element')
   })
 
-  it('warns on invalid URLs', () => {
+  it('warns on invalid URLs', async () => {
     const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <sitemap>
@@ -112,7 +112,7 @@ describe('parseSitemapIndex', () => {
   </sitemap>
 </sitemapindex>`
 
-    const { entries, warnings } = parseSitemapIndex(xml)
+    const { entries, warnings } = await parseSitemapIndex(xml)
     expect(entries).toEqual([
       { loc: 'https://example.com/valid.xml' },
     ])
@@ -121,7 +121,7 @@ describe('parseSitemapIndex', () => {
     expect(warnings[0].context?.url).toBe('not-a-url')
   })
 
-  it('trims whitespace from values', () => {
+  it('trims whitespace from values', async () => {
     const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <sitemap>
@@ -130,21 +130,21 @@ describe('parseSitemapIndex', () => {
   </sitemap>
 </sitemapindex>`
 
-    const { entries } = parseSitemapIndex(xml)
+    const { entries } = await parseSitemapIndex(xml)
     expect(entries[0].loc).toBe('https://example.com/sitemap.xml')
     expect(entries[0].lastmod).toBe('2024-01-15')
   })
 
-  it('throws on empty input', () => {
-    expect(() => parseSitemapIndex('')).toThrow('Empty XML input provided')
+  it('throws on empty input', async () => {
+    await expect(parseSitemapIndex('')).rejects.toThrow('Empty XML input provided')
   })
 
-  it('throws on non-sitemapindex XML', () => {
+  it('throws on non-sitemapindex XML', async () => {
     const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://example.com</loc></url>
 </urlset>`
 
-    expect(() => parseSitemapIndex(xml)).toThrow('XML does not contain a valid sitemapindex element')
+    await expect(parseSitemapIndex(xml)).rejects.toThrow('XML does not contain a valid sitemapindex element')
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`fast-xml-parser` was imported eagerly at the top of `parseSitemapIndex.ts`, adding it to the runtime bundle even though it is only consumed by the debug-production route. The import is now deferred to the function call so the parser is loaded on demand, and `parseSitemapIndex` becomes async (the only call site is updated to await it).