### PR TITLE
perf: share resolved-URL cache across sitemap chunks

### DIFF
--- a/docs/content/2.advanced/2.performance.md
+++ b/docs/content/2.advanced/2.performance.md
@@ -63,6 +63,16 @@ Additionally, you may want to consider the following experimental options that m
 - `experimentalCompression` - Gzip's and streams the sitemap
 - `experimentalWarmUp` - Creates the sitemaps when Nitro starts
 
+### Very large sites (100k+ URLs)
+
+For sites at this scale, two practices matter most:
+
+1. **Cache the source endpoint.** Use `defineCachedEventHandler` on any `/api/*` route fed into `sources`. Without this, every cache miss (and every fresh chunk) re-hits your backend.
+
+2. **Set generous chunk sizes.** Search engines accept up to 50,000 URLs per file. The default `defaultSitemapsChunkSize` of 1000 generates 50× more chunks than necessary; bumping to `5000`–`50000` directly reduces total work and cache entries.
+
+Within a single sitemap, all chunks share one resolved-URLs computation (sources are fetched, normalised, and sorted once per `cacheMaxAgeSeconds` window — not once per chunk). Splitting one large sitemap into per-shard sitemaps (e.g. one per locale or content type) is still useful when shards have different cache lifetimes or different sources.
+
 ## Zero Runtime Mode
 
 If your sitemap URLs only change when you deploy (not at runtime), you can enable `zeroRuntime` to generate sitemaps at build time and eliminate sitemap generation code from your server bundle.
@@ -101,9 +111,7 @@ export default defineNuxtConfig({
 
 If you want to disable caching, set `cacheMaxAgeSeconds` to `false` or `0`.
 
-::note
-The server-side SWR cache is currently limited to 10 minutes by default to ensure sitemaps don't stay stale for too long on the server.
-::
+`cacheMaxAgeSeconds` controls both the HTTP `Cache-Control` header and the server-side SWR cache TTL. For high-volume sites, raising it to several hours significantly reduces origin load.
 
 ### Cache Driver
 

--- a/docs/content/2.advanced/3.chunking-sources.md
+++ b/docs/content/2.advanced/3.chunking-sources.md
@@ -76,6 +76,26 @@ export default defineNuxtConfig({
 })
 ```
 
+## Skipping the index source fetch (`chunkCount`)
+
+By default the sitemap index calls your source to count URLs, so it knows how many `<sitemap>` entries to emit. At very large scale this cold-start fetch is the bottleneck. If you already know the number of chunks, declare it upfront and the index will skip the fetch entirely:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  sitemap: {
+    sitemaps: {
+      posts: {
+        sources: ['/api/posts'],
+        chunks: 5000,
+        chunkCount: 100, // 100 chunk entries, no source fetch in the index
+      },
+    },
+  },
+})
+```
+
+Per-chunk renders still fetch on demand and slice. If your data set grows past the declared count, tail entries are unreachable; if it shrinks, trailing chunks render empty. Update the value when your data set changes (or remove it to fall back to fetching).
+
 ## Practical Examples
 
 ### E-commerce Site

--- a/src/module.ts
+++ b/src/module.ts
@@ -818,7 +818,10 @@ export default defineNuxtModule<ModuleOptions>({
       cacheMaxAgeSeconds: runtimeConfig.cacheMaxAgeSeconds,
       debug: runtimeConfig.debug,
     }
-    const { cacheMaxAgeSeconds: _c, debug: _d, ...staticRuntimeConfig } = runtimeConfig
+    // cacheMaxAgeSeconds is duplicated: dynamic copy lets users override the HTTP cache header via
+    // env vars at runtime; static copy is read at server startup to size the in-memory cache layer
+    // (defineCachedFunction takes maxAge as a static option, not a runtime callback).
+    const { debug: _d, ...staticRuntimeConfig } = runtimeConfig
     // @ts-expect-error untyped
     nuxt.options.runtimeConfig.sitemap = dynamicRuntimeConfig
     nuxt.hook('nitro:config', (nitroConfig) => {

--- a/src/runtime/server/plugins/warm-up.ts
+++ b/src/runtime/server/plugins/warm-up.ts
@@ -1,17 +1,34 @@
 import { defineNitroPlugin } from 'nitropack/runtime'
-import { withLeadingSlash } from 'ufo'
+import { joinURL, withLeadingSlash } from 'ufo'
 import { useSitemapRuntimeConfig } from '../utils'
 
 export default defineNitroPlugin((nitroApp) => {
-  const { sitemaps } = useSitemapRuntimeConfig()
+  const { sitemaps, sitemapsPathPrefix } = useSitemapRuntimeConfig()
   const queue: (() => Promise<Response>)[] = []
   const timeoutIds: NodeJS.Timeout[] = []
 
-  const sitemapsWithRoutes = Object.entries(sitemaps)
-    .filter(([, sitemap]) => sitemap._route)
+  const enqueue = (path: string) => {
+    queue.push(() => nitroApp.localFetch(withLeadingSlash(path), {}))
+  }
 
-  for (const [, sitemap] of sitemapsWithRoutes)
-    queue.push(() => nitroApp.localFetch(withLeadingSlash(sitemap._route), {}))
+  for (const [name, sitemap] of Object.entries(sitemaps)) {
+    if (!sitemap._route)
+      continue
+    if (name === 'index') {
+      enqueue(sitemap._route)
+      continue
+    }
+    // Chunked sitemaps don't expose the base route — the catch-all serves a non-chunked variant
+    // that bypasses chunk slicing. Warm chunk-0 instead so the shared resolved-URLs cache is
+    // populated with the correct filter pass; sibling chunk requests then hit that cache.
+    const def = sitemap as { chunks?: unknown, _isChunking?: boolean, _route: string }
+    if (def.chunks || def._isChunking) {
+      enqueue(joinURL(sitemapsPathPrefix || '/', `${name}-0.xml`))
+    }
+    else {
+      enqueue(sitemap._route)
+    }
+  }
 
   // run async
   const initialTimeout = setTimeout(() => {

--- a/src/runtime/server/sitemap/builder/sitemap-index.ts
+++ b/src/runtime/server/sitemap/builder/sitemap-index.ts
@@ -3,21 +3,18 @@ import type { NitroApp } from 'nitropack/types'
 import type {
   ModuleRuntimeConfig,
   NitroUrlResolvers,
-  ResolvedSitemapUrl,
   SitemapIndexEntry,
-  SitemapInputCtx,
-  SitemapSourcesHookCtx,
-  SitemapUrl,
 } from '../../../types'
-import { defu } from 'defu'
+// @ts-expect-error virtual module
+import staticConfig from '#sitemap-virtual/static-config.mjs'
 import { getHeader } from 'h3'
-import { defineCachedFunction, useRuntimeConfig } from 'nitropack/runtime'
+import { defineCachedFunction } from 'nitropack/runtime'
 import { joinURL, withQuery } from 'ufo'
 import { normaliseDate } from '../urlset/normalise'
-import { sortInPlace } from '../urlset/sort'
-import { childSitemapSources, globalSitemapSources, resolveSitemapSources } from '../urlset/sources'
-import { resolveSitemapEntries } from './sitemap'
+import { getResolvedSitemapUrls } from './sitemap'
 import { escapeValueForXml } from './xml'
+
+const SERVER_CACHE_MAX_AGE = (staticConfig.cacheMaxAgeSeconds as number | false) || 60 * 10
 
 // Create cached wrapper for sitemap index building
 const buildSitemapIndexCached = defineCachedFunction(
@@ -27,7 +24,7 @@ const buildSitemapIndexCached = defineCachedFunction(
   {
     name: 'sitemap:index',
     group: 'sitemap',
-    maxAge: 60 * 10, // 10 minutes default
+    maxAge: SERVER_CACHE_MAX_AGE,
     base: 'sitemap', // Use the sitemap storage
     getKey: (event: H3Event) => {
       // Include headers that could affect the output in the cache key
@@ -42,24 +39,15 @@ const buildSitemapIndexCached = defineCachedFunction(
 async function buildSitemapIndexInternal(resolvers: NitroUrlResolvers, runtimeConfig: ModuleRuntimeConfig, nitro?: NitroApp): Promise<{ entries: SitemapIndexEntry[], failedSources: Array<{ url: string, error: string }> }> {
   const {
     sitemaps,
-    // enhancing
     autoLastmod,
-    // chunking
     defaultSitemapsChunkSize,
-    autoI18n,
-    isI18nMapped,
-    sortEntries,
     sitemapsPathPrefix,
   } = runtimeConfig
 
   if (!sitemaps)
     throw new Error('Attempting to build a sitemap index without required `sitemaps` configuration.')
 
-  function maybeSort(urls: ResolvedSitemapUrl[]) {
-    return sortEntries ? sortInPlace(urls) : urls
-  }
-
-  const chunks: Record<string | number, { urls: SitemapUrl[] }> = {}
+  const nonChunkedNames: string[] = []
   const allFailedSources: Array<{ url: string, error: string }> = []
 
   // Process all sitemaps to determine chunks
@@ -76,149 +64,72 @@ async function buildSitemapIndexInternal(resolvers: NitroUrlResolvers, runtimeCo
       sitemapConfig._chunkSize = sitemapConfig.chunkSize || (typeof sitemapConfig.chunks === 'number' ? sitemapConfig.chunks : (defaultSitemapsChunkSize || 1000))
     }
     else {
-      // Non-chunked sitemap
-      chunks[sitemapName] = chunks[sitemapName] || { urls: [] }
+      nonChunkedNames.push(sitemapName)
     }
   }
 
-  // Handle auto-chunking if enabled
+  // sitemap.org defines index <lastmod> as the file's modification time, not the max of URL
+  // lastmods inside it. Our default sort is by `loc`, so per-chunk URL lastmods were already
+  // misleading. Emit `new Date()` when autoLastmod is on, otherwise no <lastmod>. This avoids
+  // a slice/filter/sort pass per chunk and lets us count without holding URLs in memory.
+  const indexLastmod = autoLastmod ? normaliseDate(new Date()) : undefined
+  const entries: SitemapIndexEntry[] = []
+
+  // Auto-chunking: count URLs to know how many chunk entries to emit. Shares cache with the
+  // chunk handler (matchName 'sitemap', isChunked true) so the source fetch is one-shot.
   if (typeof sitemaps.chunks !== 'undefined') {
     const sitemap = sitemaps.chunks
-    // we need to figure out how many entries we're dealing with
-    // Note: globalSitemapSources() returns a fresh copy
-    let sourcesInput = await globalSitemapSources()
-
-    // Allow hook to modify sources before resolution
-    if (nitro && resolvers.event) {
-      const ctx: SitemapSourcesHookCtx = {
-        event: resolvers.event,
-        sitemapName: sitemap.sitemapName,
-        sources: sourcesInput,
+    const resolved = await getResolvedSitemapUrls(sitemap, 'sitemap', true, resolvers, runtimeConfig, nitro)
+    allFailedSources.push(...resolved.failedSources)
+    const chunkCount = Math.ceil(resolved.urls.length / (defaultSitemapsChunkSize as number))
+    for (let i = 0; i < chunkCount; i++) {
+      const entry: SitemapIndexEntry = {
+        _sitemapName: String(i),
+        sitemap: resolvers.canonicalUrlResolver(joinURL(sitemapsPathPrefix || '', `/${i}.xml`)),
       }
-      await nitro.hooks.callHook('sitemap:sources', ctx)
-      sourcesInput = ctx.sources
+      if (indexLastmod)
+        entry.lastmod = indexLastmod
+      entries.push(entry)
     }
-
-    const sources = await resolveSitemapSources(sourcesInput, resolvers.event)
-
-    // Collect failed sources
-    const failedSources = sources
-      .filter(source => source.error && source._isFailure)
-      .map(source => ({
-        url: typeof source.fetch === 'string' ? source.fetch : (source.fetch?.[0] || 'unknown'),
-        error: source.error || 'Unknown error',
-      }))
-    allFailedSources.push(...failedSources)
-
-    const resolvedCtx: SitemapInputCtx = {
-      urls: sources.flatMap(s => s.urls),
-      sitemapName: sitemap.sitemapName,
-      event: resolvers.event,
-    }
-    await nitro?.hooks.callHook('sitemap:input', resolvedCtx)
-    const normalisedUrls = resolveSitemapEntries(sitemap, resolvedCtx.urls, { autoI18n, isI18nMapped }, resolvers, useRuntimeConfig().app.baseURL)
-    // 2. enhance
-    const enhancedUrls: ResolvedSitemapUrl[] = normalisedUrls
-      .map(e => defu(e, sitemap.defaults) as ResolvedSitemapUrl)
-    const sortedUrls = maybeSort(enhancedUrls)
-    // split into the max size which should be 1000
-    sortedUrls.forEach((url, i) => {
-      const chunkIndex = Math.floor(i / (defaultSitemapsChunkSize as number))
-      chunks[chunkIndex] = chunks[chunkIndex] || { urls: [] }
-      chunks[chunkIndex].urls.push(url)
-    })
   }
 
-  const entries: SitemapIndexEntry[] = []
-  // Process regular chunks
-  for (const name in chunks) {
-    const sitemap = chunks[name]!
+  // Non-chunked named sitemaps: just emit one entry each, no fetch.
+  for (const name of nonChunkedNames) {
     const entry: SitemapIndexEntry = {
       _sitemapName: name,
       sitemap: resolvers.canonicalUrlResolver(joinURL(sitemapsPathPrefix || '', `/${name}.xml`)),
     }
-    let lastmod = sitemap.urls
-      .filter(a => !!a?.lastmod)
-      .map(a => typeof a.lastmod === 'string' ? new Date(a.lastmod) : a.lastmod)
-      .sort((a?: Date, b?: Date) => (b?.getTime() || 0) - (a?.getTime() || 0))?.[0]
-    if (!lastmod && autoLastmod)
-      lastmod = new Date()
-
-    if (lastmod)
-      entry.lastmod = normaliseDate(lastmod)
+    if (indexLastmod)
+      entry.lastmod = indexLastmod
     entries.push(entry)
   }
 
-  // Process chunked named sitemaps
+  // Chunked named sitemaps. Skip the source fetch when `chunkCount` is declared upfront.
   for (const sitemapName in sitemaps) {
     const sitemapConfig = sitemaps[sitemapName]!
     if (sitemapName !== 'index' && sitemapConfig._isChunking) {
       const chunkSize = sitemapConfig._chunkSize || defaultSitemapsChunkSize || 1000
 
-      // We need to determine how many chunks this sitemap will have
-      // This requires knowing the total count of URLs, which we'll get from sources
-      // Note: globalSitemapSources() and childSitemapSources() return fresh copies
-      let sourcesInput = sitemapConfig.includeAppSources
-        ? [...await globalSitemapSources(), ...await childSitemapSources(sitemapConfig)]
-        : await childSitemapSources(sitemapConfig)
-
-      // Allow hook to modify sources before resolution
-      if (nitro && resolvers.event) {
-        const ctx: SitemapSourcesHookCtx = {
-          event: resolvers.event,
-          sitemapName: sitemapConfig.sitemapName,
-          sources: sourcesInput,
-        }
-        await nitro.hooks.callHook('sitemap:sources', ctx)
-        sourcesInput = ctx.sources
+      let chunkCount: number
+      if (typeof sitemapConfig.chunkCount === 'number' && sitemapConfig.chunkCount > 0) {
+        chunkCount = sitemapConfig.chunkCount
+      }
+      else {
+        const resolved = await getResolvedSitemapUrls(sitemapConfig, sitemapName, true, resolvers, runtimeConfig, nitro)
+        allFailedSources.push(...resolved.failedSources)
+        chunkCount = Math.ceil(resolved.urls.length / chunkSize)
       }
 
-      const sources = await resolveSitemapSources(sourcesInput, resolvers.event)
-
-      // Collect failed sources
-      const failedSources = sources
-        .filter(source => source.error && source._isFailure)
-        .map(source => ({
-          url: typeof source.fetch === 'string' ? source.fetch : (source.fetch?.[0] || 'unknown'),
-          error: source.error || 'Unknown error',
-        }))
-      allFailedSources.push(...failedSources)
-
-      const resolvedCtx: SitemapInputCtx = {
-        urls: sources.flatMap(s => s.urls),
-        sitemapName: sitemapConfig.sitemapName,
-        event: resolvers.event,
-      }
-      await nitro?.hooks.callHook('sitemap:input', resolvedCtx)
-
-      const normalisedUrls = resolveSitemapEntries(sitemapConfig, resolvedCtx.urls, { autoI18n, isI18nMapped }, resolvers, useRuntimeConfig().app.baseURL)
-      const totalUrls = normalisedUrls.length
-      const chunkCount = Math.ceil(totalUrls / chunkSize)
-
-      // Store chunk count for validation in route handler
       sitemapConfig._chunkCount = chunkCount
 
-      // Create entries for each chunk
       for (let i = 0; i < chunkCount; i++) {
         const chunkName = `${sitemapName}-${i}`
         const entry: SitemapIndexEntry = {
           _sitemapName: chunkName,
           sitemap: resolvers.canonicalUrlResolver(joinURL(sitemapsPathPrefix || '', `/${chunkName}.xml`)),
         }
-
-        // Get the URLs for this chunk to find lastmod
-        const chunkUrls = normalisedUrls.slice(i * chunkSize, (i + 1) * chunkSize)
-        let lastmod = chunkUrls
-          .filter(a => !!a?.lastmod)
-          .map(a => typeof a.lastmod === 'string' ? new Date(a.lastmod) : a.lastmod)
-          .sort((a?: Date, b?: Date) => (b?.getTime() || 0) - (a?.getTime() || 0))?.[0]
-
-        if (!lastmod && autoLastmod)
-          lastmod = new Date()
-
-        if (lastmod)
-          entry.lastmod = normaliseDate(lastmod)
-
+        if (indexLastmod)
+          entry.lastmod = indexLastmod
         entries.push(entry)
       }
     }

--- a/src/runtime/server/sitemap/builder/sitemap.ts
+++ b/src/runtime/server/sitemap/builder/sitemap.ts
@@ -1,3 +1,4 @@
+import type { H3Event } from 'h3'
 import type { NitroApp } from 'nitropack/types'
 import type {
   AlternativeEntry,
@@ -11,7 +12,10 @@ import type {
   SitemapUrl,
   SitemapUrlInput,
 } from '../../../types'
-import { useRuntimeConfig } from 'nitropack/runtime'
+// @ts-expect-error virtual module
+import staticConfig from '#sitemap-virtual/static-config.mjs'
+import { getHeader } from 'h3'
+import { defineCachedFunction, useRuntimeConfig } from 'nitropack/runtime'
 import { resolveSitePath } from 'nuxt-site-config/urls'
 import { joinURL, withHttps } from 'ufo'
 import { applyDynamicParams, createPathFilter, findPageMapping, logger, splitForLocales } from '../../../utils-pure'
@@ -19,6 +23,8 @@ import { preNormalizeEntry } from '../urlset/normalise'
 import { sortInPlace } from '../urlset/sort'
 import { childSitemapSources, globalSitemapSources, resolveSitemapSources } from '../urlset/sources'
 import { parseChunkInfo, sliceUrlsForChunk } from '../utils/chunk'
+
+const SERVER_CACHE_MAX_AGE = (staticConfig.cacheMaxAgeSeconds as number | false) || 60 * 10
 
 export interface NormalizedI18n extends ResolvedSitemapUrl {
   _pathWithoutPrefix: string
@@ -225,72 +231,32 @@ export function resolveSitemapEntries(sitemap: SitemapDefinition, urls: SitemapU
   return _urls
 }
 
-export async function buildSitemapUrls(sitemap: SitemapDefinition, resolvers: NitroUrlResolvers, runtimeConfig: ModuleRuntimeConfig, nitro?: NitroApp): Promise<{ urls: ResolvedSitemapUrl[], failedSources: Array<{ url: string, error: string }> }> {
-  // 0. resolve sources
-  // 1. normalise
-  // 2. filter
-  // 3. enhance
-  // 4. sort
-  // 5. chunking
-  // 6. nitro hooks
-  // 7. normalise and sort again
-  const {
-    sitemaps,
-    // enhancing
-    autoI18n,
-    isI18nMapped,
-    isMultiSitemap,
-    // sorting
-    sortEntries,
-    // chunking
-    defaultSitemapsChunkSize,
-  } = runtimeConfig
+export interface ResolvedSitemapUrlsResult {
+  urls: ResolvedSitemapUrl[]
+  failedSources: Array<{ url: string, error: string }>
+}
 
-  // Parse chunk information from the sitemap name
-  const chunkSize = defaultSitemapsChunkSize || undefined
-  const chunkInfo = parseChunkInfo(sitemap.sitemapName, sitemaps, chunkSize)
+// Chunk-agnostic computation: fetch sources, run hooks, normalise, filter, sort.
+// Returns the full sorted array; chunked sitemaps slice from this on the way out.
+// All chunks of the same base sitemap share one cache entry.
+export async function buildResolvedSitemapUrls(
+  effectiveSitemap: SitemapDefinition,
+  matchName: string,
+  isChunked: boolean,
+  resolvers: NitroUrlResolvers,
+  runtimeConfig: ModuleRuntimeConfig,
+  nitro?: NitroApp,
+): Promise<ResolvedSitemapUrlsResult> {
+  const { sitemaps, autoI18n, isI18nMapped, isMultiSitemap, sortEntries } = runtimeConfig
 
-  function maybeSort(urls: ResolvedSitemapUrl[]) {
-    return sortEntries ? sortInPlace(urls) : urls
-  }
-
-  function maybeSlice<T extends SitemapUrlInput[] | ResolvedSitemapUrl[]>(urls: T): T {
-    return sliceUrlsForChunk(urls, sitemap.sitemapName, sitemaps, chunkSize) as T
-  }
-  if (autoI18n?.differentDomains) {
-    const domain = autoI18n.locales.find(e => e.language === sitemap.sitemapName || e.code === sitemap.sitemapName)?.domain
-    if (domain) {
-      const _tester = resolvers.canonicalUrlResolver
-      resolvers.canonicalUrlResolver = (path: string) => resolveSitePath(path, {
-        absolute: true,
-        withBase: false,
-        siteUrl: withHttps(domain),
-        trailingSlash: _tester('/test/').endsWith('/'),
-        base: '/',
-      })
-    }
-  }
-  // 0. resolve sources
-  // For chunked sitemaps, we need to use the base sitemap's sources
-  let effectiveSitemap = sitemap
-  const baseSitemapName = chunkInfo.baseSitemapName
-
-  // If this is a chunked sitemap, use the base sitemap config for sources
-  if (chunkInfo.isChunked && baseSitemapName !== sitemap.sitemapName && sitemaps[baseSitemapName]) {
-    effectiveSitemap = sitemaps[baseSitemapName]
-  }
-
-  // always fetch all sitemap data for the primary sitemap
-  // Note: globalSitemapSources() and childSitemapSources() return fresh copies
   let sourcesInput = effectiveSitemap.includeAppSources
     ? [...await globalSitemapSources(), ...await childSitemapSources(effectiveSitemap)]
     : await childSitemapSources(effectiveSitemap)
 
-  // Allow hook to modify sources before resolution
   if (nitro && resolvers.event) {
     const ctx: SitemapSourcesHookCtx = {
       event: resolvers.event,
-      sitemapName: baseSitemapName,
+      sitemapName: matchName,
       sources: sourcesInput,
     }
     await nitro.hooks.callHook('sitemap:sources', ctx)
@@ -299,7 +265,6 @@ export async function buildSitemapUrls(sitemap: SitemapDefinition, resolvers: Ni
 
   const sources = await resolveSitemapSources(sourcesInput, resolvers.event)
 
-  // Extract failed sources for display
   const failedSources = sources
     .filter(source => source.error && source._isFailure)
     .map(source => ({
@@ -309,18 +274,17 @@ export async function buildSitemapUrls(sitemap: SitemapDefinition, resolvers: Ni
 
   const resolvedCtx: SitemapInputCtx = {
     urls: sources.flatMap(s => s.urls),
-    sitemapName: sitemap.sitemapName,
+    sitemapName: matchName,
     event: resolvers.event,
   }
   await nitro?.hooks.callHook('sitemap:input', resolvedCtx)
-  const enhancedUrls = resolveSitemapEntries(sitemap, resolvedCtx.urls, { autoI18n, isI18nMapped }, resolvers, useRuntimeConfig().app.baseURL)
+  const enhancedUrls = resolveSitemapEntries(effectiveSitemap, resolvedCtx.urls, { autoI18n, isI18nMapped }, resolvers, useRuntimeConfig().app.baseURL)
 
   if (isMultiSitemap) {
     const sitemapNames = Object.keys(sitemaps).filter(k => k !== 'index')
     // @ts-expect-error loose typing
     const warnedSitemaps = nitro?._sitemapWarnedSitemaps || new Set<string>()
     for (const e of enhancedUrls) {
-      // Check if _sitemap matches any sitemap name directly OR via locale prefix (e.g., "en-US" matches "en-US-pages")
       const hasMatchingSitemap = typeof e._sitemap === 'string'
         && (sitemapNames.includes(e._sitemap) || (isI18nMapped && sitemapNames.some(name => name.startsWith(`${e._sitemap}-`))))
       if (typeof e._sitemap === 'string' && !hasMatchingSitemap) {
@@ -336,24 +300,99 @@ export async function buildSitemapUrls(sitemap: SitemapDefinition, resolvers: Ni
     }
   }
 
-  // 3. filtered urls
   const filteredUrls = enhancedUrls.filter((e) => {
     if (e._sitemap === false)
       return false
-    if (isMultiSitemap && e._sitemap && sitemap.sitemapName) {
-      if (sitemap._isChunking)
-        return e._sitemap === baseSitemapName || (isI18nMapped && sitemap.sitemapName.startsWith(`${e._sitemap}-`))
-      // Match exact sitemap name OR locale-prefixed sitemap (e.g., "en-US" matches "en-US-pages")
-      return e._sitemap === sitemap.sitemapName || (isI18nMapped && sitemap.sitemapName.startsWith(`${e._sitemap}-`))
+    if (isMultiSitemap && e._sitemap && matchName) {
+      if (isChunked)
+        return e._sitemap === matchName
+      return e._sitemap === matchName || (isI18nMapped && matchName.startsWith(`${e._sitemap}-`))
     }
     return true
   })
-  // 4. sort
-  const sortedUrls = maybeSort(filteredUrls)
-  // 5. maybe slice for chunked
-  // if we're rendering a partial sitemap, slice the entries
-  const urls = maybeSlice(sortedUrls)
+
+  const urls = sortEntries ? sortInPlace(filteredUrls) : filteredUrls
   return { urls, failedSources }
+}
+
+export const buildResolvedSitemapUrlsCached = defineCachedFunction(
+  async (
+    _event: H3Event,
+    effectiveSitemap: SitemapDefinition,
+    matchName: string,
+    isChunked: boolean,
+    resolvers: NitroUrlResolvers,
+    runtimeConfig: ModuleRuntimeConfig,
+    nitro?: NitroApp,
+  ) => buildResolvedSitemapUrls(effectiveSitemap, matchName, isChunked, resolvers, runtimeConfig, nitro),
+  {
+    name: 'sitemap:resolved-urls',
+    group: 'sitemap',
+    base: 'sitemap',
+    maxAge: SERVER_CACHE_MAX_AGE,
+    getKey: (event, _effectiveSitemap, matchName, isChunked) => {
+      const host = getHeader(event, 'host') || getHeader(event, 'x-forwarded-host') || ''
+      const proto = getHeader(event, 'x-forwarded-proto') || 'https'
+      return `resolved-${isChunked ? 'chunked-' : ''}${matchName}-${proto}-${host}`
+    },
+    swr: true,
+  },
+)
+
+// Routes between Nitro's storage-backed cache (production) and direct execution. Chunks of the
+// same base sitemap share one cache entry so the source fetch + normalize + sort runs once per
+// `cacheMaxAgeSeconds` window. Edge-runtime safe: relies on Nitro's storage layer, no module
+// state. Dev and prerender skip the cache (prerender to avoid poisoning from early empty-source
+// reads; dev to keep iteration fast).
+export async function getResolvedSitemapUrls(
+  effectiveSitemap: SitemapDefinition,
+  matchName: string,
+  isChunked: boolean,
+  resolvers: NitroUrlResolvers,
+  runtimeConfig: ModuleRuntimeConfig,
+  nitro?: NitroApp,
+): Promise<ResolvedSitemapUrlsResult> {
+  const event = resolvers.event
+  const shouldCache = !import.meta.dev && !import.meta.prerender && typeof runtimeConfig.cacheMaxAgeSeconds === 'number' && runtimeConfig.cacheMaxAgeSeconds > 0
+  if (shouldCache && event) {
+    return buildResolvedSitemapUrlsCached(event, effectiveSitemap, matchName, isChunked, resolvers, runtimeConfig, nitro)
+  }
+  return buildResolvedSitemapUrls(effectiveSitemap, matchName, isChunked, resolvers, runtimeConfig, nitro)
+}
+
+export async function buildSitemapUrls(sitemap: SitemapDefinition, resolvers: NitroUrlResolvers, runtimeConfig: ModuleRuntimeConfig, nitro?: NitroApp): Promise<ResolvedSitemapUrlsResult> {
+  const { sitemaps, autoI18n, defaultSitemapsChunkSize } = runtimeConfig
+
+  const chunkSize = defaultSitemapsChunkSize || undefined
+  const chunkInfo = parseChunkInfo(sitemap.sitemapName, sitemaps, chunkSize)
+
+  if (autoI18n?.differentDomains) {
+    const domain = autoI18n.locales.find(e => e.language === sitemap.sitemapName || e.code === sitemap.sitemapName)?.domain
+    if (domain) {
+      const _tester = resolvers.canonicalUrlResolver
+      resolvers.canonicalUrlResolver = (path: string) => resolveSitePath(path, {
+        absolute: true,
+        withBase: false,
+        siteUrl: withHttps(domain),
+        trailingSlash: _tester('/test/').endsWith('/'),
+        base: '/',
+      })
+    }
+  }
+
+  // For chunked sitemaps the base sitemap config holds the sources; all chunks share one cache entry.
+  let effectiveSitemap = sitemap
+  const baseSitemapName = chunkInfo.baseSitemapName
+  if (chunkInfo.isChunked && baseSitemapName !== sitemap.sitemapName && sitemaps[baseSitemapName]) {
+    effectiveSitemap = sitemaps[baseSitemapName]
+  }
+
+  const matchName = chunkInfo.isChunked ? baseSitemapName : sitemap.sitemapName
+  const resolved = await getResolvedSitemapUrls(effectiveSitemap, matchName, chunkInfo.isChunked, resolvers, runtimeConfig, nitro)
+
+  // Slice last so all chunks of the same base reuse the cached sorted array.
+  const urls = sliceUrlsForChunk(resolved.urls, sitemap.sitemapName, sitemaps, chunkSize)
+  return { urls, failedSources: resolved.failedSources }
 }
 
 export { urlsToXml } from './xml'

--- a/src/runtime/server/sitemap/nitro.ts
+++ b/src/runtime/server/sitemap/nitro.ts
@@ -11,6 +11,8 @@ import type {
 import { getPathRobotConfig } from '#internal/nuxt-robots/getPathRobotConfig' // can't solve this
 import { getSiteConfig } from '#site-config/server/composables/getSiteConfig'
 import { createSitePathResolver } from '#site-config/server/composables/utils'
+// @ts-expect-error virtual module
+import staticConfig from '#sitemap-virtual/static-config.mjs'
 import { defu } from 'defu'
 import { createError, getHeader, getQuery, setHeader } from 'h3'
 import { defineCachedFunction, useNitroApp } from 'nitropack/runtime'
@@ -20,6 +22,10 @@ import { createNitroRouteRuleMatcher } from '../kit'
 import { buildSitemapUrls, urlsToXml } from './builder/sitemap'
 import { normaliseEntry, preNormalizeEntry } from './urlset/normalise'
 import { sortInPlace } from './urlset/sort'
+
+// Read at module init: defineCachedFunction takes a static maxAge. Falls back to 10 minutes
+// when caching is disabled in static config (still bypassed at request time via shouldCache).
+const SERVER_CACHE_MAX_AGE = (staticConfig.cacheMaxAgeSeconds as number | false) || 60 * 10
 
 interface SitemapNitroApp extends NitroApp {
   _sitemapWarned?: boolean
@@ -169,7 +175,7 @@ const buildSitemapXmlCached = defineCachedFunction(
   {
     name: 'sitemap:xml',
     group: 'sitemap',
-    maxAge: 60 * 10, // Default 10 minutes
+    maxAge: SERVER_CACHE_MAX_AGE,
     base: 'sitemap', // Use the sitemap storage
     getKey: (event: H3Event, definition: SitemapDefinition) => {
       // Include headers that could affect the output in the cache key

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -342,6 +342,16 @@ export interface SitemapDefinition {
    */
   chunkSize?: number
   /**
+   * Pre-declare the number of chunks this sitemap will produce. When set, the sitemap index
+   * renders this many chunk entries without fetching the source data — useful at very large
+   * scale where the cold-start fetch is the bottleneck. Per-chunk renders still fetch on
+   * demand and slice. If the actual data produces fewer URLs than declared, tail chunks render
+   * empty; if more, the extras are unreachable. Update this when your data set grows.
+   *
+   * @example 100
+   */
+  chunkCount?: number
+  /**
    * @internal
    */
   _route?: string

--- a/test/e2e/chunks/chunk-count.test.ts
+++ b/test/e2e/chunks/chunk-count.test.ts
@@ -1,0 +1,30 @@
+import { createResolver } from '@nuxt/kit'
+import { $fetch, setup } from '@nuxt/test-utils'
+import { describe, expect, it } from 'vitest'
+
+const { resolve } = createResolver(import.meta.url)
+
+await setup({
+  rootDir: resolve('../../fixtures/chunk-count'),
+})
+
+describe('declared chunkCount', () => {
+  it('renders the index from the declared count without hitting the source', async () => {
+    const before = (await $fetch<{ count: number }>('/api/posts-call-count')).count
+    const indexXml = await $fetch<string>('/sitemap_index.xml')
+    const after = (await $fetch<{ count: number }>('/api/posts-call-count')).count
+
+    expect(after - before).toBe(0)
+
+    for (let i = 0; i < 4; i++) {
+      expect(indexXml).toContain(`/__sitemap__/posts-${i}.xml`)
+    }
+    expect(indexXml).not.toContain('/__sitemap__/posts-4.xml')
+  }, 30000)
+
+  it('chunks fetch sources on demand and the data is correct', async () => {
+    const chunk0 = await $fetch<string>('/__sitemap__/posts-0.xml')
+    expect(chunk0).toContain('/posts/1')
+    expect(chunk0).toContain('/posts/5')
+  }, 30000)
+})

--- a/test/e2e/chunks/memoization.test.ts
+++ b/test/e2e/chunks/memoization.test.ts
@@ -1,0 +1,35 @@
+import { createResolver } from '@nuxt/kit'
+import { $fetch, setup } from '@nuxt/test-utils'
+import { describe, expect, it } from 'vitest'
+
+const { resolve } = createResolver(import.meta.url)
+
+await setup({
+  rootDir: resolve('../../fixtures/chunk-cache'),
+})
+
+describe('chunk resolved-urls memoization', () => {
+  it('all chunks of the same base share one source fetch', async () => {
+    // 17 entries × chunk size 5 → 4 chunks (0..3)
+    await $fetch('/__sitemap__/posts-0.xml')
+    await $fetch('/__sitemap__/posts-1.xml')
+    await $fetch('/__sitemap__/posts-2.xml')
+    await $fetch('/__sitemap__/posts-3.xml')
+
+    const { count } = await $fetch<{ count: number }>('/api/source-call-count')
+    expect(count).toBe(1)
+  }, 30000)
+
+  it('chunked output reflects the shared sorted slice', async () => {
+    const chunk0 = await $fetch<string>('/__sitemap__/posts-0.xml')
+    const chunk3 = await $fetch<string>('/__sitemap__/posts-3.xml')
+
+    expect(chunk0).toContain('/posts/1')
+    expect(chunk0).toContain('/posts/5')
+    expect(chunk0).not.toContain('/posts/6')
+
+    expect(chunk3).toContain('/posts/16')
+    expect(chunk3).toContain('/posts/17')
+    expect(chunk3).not.toContain('/posts/15')
+  }, 30000)
+})

--- a/test/fixtures/chunk-cache/app.vue
+++ b/test/fixtures/chunk-cache/app.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>chunk cache fixture</div>
+</template>

--- a/test/fixtures/chunk-cache/nuxt.config.ts
+++ b/test/fixtures/chunk-cache/nuxt.config.ts
@@ -1,0 +1,18 @@
+import NuxtSitemap from '../../../src/module'
+
+export default defineNuxtConfig({
+  modules: [NuxtSitemap],
+  site: { url: 'https://nuxtseo.com' },
+  sitemap: {
+    autoLastmod: false,
+    credits: false,
+    cacheMaxAgeSeconds: 600,
+    runtimeCacheStorage: { driver: 'memory' },
+    sitemaps: {
+      posts: {
+        sources: ['/api/posts'],
+        chunks: 5,
+      },
+    },
+  },
+})

--- a/test/fixtures/chunk-cache/server/api/posts.ts
+++ b/test/fixtures/chunk-cache/server/api/posts.ts
@@ -1,0 +1,15 @@
+import { defineEventHandler } from 'h3'
+
+declare global {
+  // eslint-disable-next-line vars-on-top, no-var
+  var __postsSourceCallCount: number
+}
+
+globalThis.__postsSourceCallCount ??= 0
+
+export default defineEventHandler(() => {
+  globalThis.__postsSourceCallCount++
+  return Array.from({ length: 17 }, (_, i) => ({
+    loc: `/posts/${i + 1}`,
+  }))
+})

--- a/test/fixtures/chunk-cache/server/api/source-call-count.ts
+++ b/test/fixtures/chunk-cache/server/api/source-call-count.ts
@@ -1,0 +1,5 @@
+import { defineEventHandler } from 'h3'
+
+export default defineEventHandler(() => {
+  return { count: globalThis.__postsSourceCallCount ?? 0 }
+})

--- a/test/fixtures/chunk-count/app.vue
+++ b/test/fixtures/chunk-count/app.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>chunk count fixture</div>
+</template>

--- a/test/fixtures/chunk-count/nuxt.config.ts
+++ b/test/fixtures/chunk-count/nuxt.config.ts
@@ -1,0 +1,17 @@
+import NuxtSitemap from '../../../src/module'
+
+export default defineNuxtConfig({
+  modules: [NuxtSitemap],
+  site: { url: 'https://nuxtseo.com' },
+  sitemap: {
+    autoLastmod: false,
+    credits: false,
+    sitemaps: {
+      posts: {
+        sources: ['/api/posts'],
+        chunks: 5,
+        chunkCount: 4,
+      },
+    },
+  },
+})

--- a/test/fixtures/chunk-count/server/api/posts-call-count.ts
+++ b/test/fixtures/chunk-count/server/api/posts-call-count.ts
@@ -1,0 +1,3 @@
+import { defineEventHandler } from 'h3'
+
+export default defineEventHandler(() => ({ count: globalThis.__chunkCountPostsCalls ?? 0 }))

--- a/test/fixtures/chunk-count/server/api/posts.ts
+++ b/test/fixtures/chunk-count/server/api/posts.ts
@@ -1,0 +1,13 @@
+import { defineEventHandler } from 'h3'
+
+declare global {
+  // eslint-disable-next-line vars-on-top, no-var
+  var __chunkCountPostsCalls: number
+}
+
+globalThis.__chunkCountPostsCalls ??= 0
+
+export default defineEventHandler(() => {
+  globalThis.__chunkCountPostsCalls++
+  return Array.from({ length: 17 }, (_, i) => ({ loc: `/posts/${i + 1}` }))
+})


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Chunked sitemaps previously re-fetched and re-sorted source data for every chunk request, plus once more in the index. At large scale that meant `N + 1` source fetches per cache window for one sitemap. This refactors the chunk pipeline so all chunks of the same base sitemap share one cached resolved-URLs computation: sources are fetched, normalised, and sorted once per `cacheMaxAgeSeconds` window, then sliced per chunk on the way out.

Other changes bundled in:

- New optional `chunkCount` per sitemap. When set, the index emits that many `<sitemap>` entries without fetching sources at all, which removes the cold-start bottleneck on very large sites. Per-chunk renders still fetch on demand. Documented trade-offs in `docs/content/2.advanced/3.chunking-sources.md`.
- `cacheMaxAgeSeconds` from the static virtual config is now wired into `defineCachedFunction`'s `maxAge` for both `sitemap:index` and `sitemap:xml` (was hardcoded to 10 minutes).
- Warm-up plugin now warms chunk-0 instead of the non-existent base route for chunked sitemaps, so the shared cache is populated correctly at startup.
- Index `<lastmod>` is now the file modification time (sitemap.org spec), not the max URL lastmod, which avoids an extra slice/filter/sort pass per chunk.
- Docs: new "Very large sites" section in `2.performance.md` with cache + chunk-size guidance, and corrected note about `cacheMaxAgeSeconds` no longer being capped at 10 minutes.

### 🧪 Tests

- `test/e2e/chunks/memoization.test.ts` — verifies the source endpoint is hit once across multiple chunk requests.
- `test/e2e/chunks/chunk-count.test.ts` — verifies the index skips the source fetch when `chunkCount` is declared.