### PR TITLE
fix: degrade gracefully when content DB query fails on serverless

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -543,15 +543,6 @@ export default defineNuxtModule<ModuleOptions>({
         route: '/__sitemap__/nuxt-content-urls.json',
         handler: resolve('./runtime/server/routes/__sitemap__/nuxt-content-urls-v3'),
       })
-      // On serverless (functions) @nuxt/content v3 restores its SQLite DB at runtime from a
-      // prerendered sql_dump.txt that lives in the CDN output, not in the function bundle, so a
-      // runtime content query 404s and yields no URLs (it degrades gracefully but silently).
-      // The query only succeeds at build, where content uses its local DB, so the sitemap must be
-      // prerendered to capture content URLs. Warn at build when we can detect the broken combo.
-      const serverlessPresets = new Set(['vercel', 'netlify', 'cloudflare', 'cloudflare-pages', 'cloudflare-module', 'aws-lambda', 'aws-amplify', 'firebase', 'edgio', 'zeabur'])
-      if (!prerenderSitemap && serverlessPresets.has(resolveNitroPreset())) {
-        logger.warn('`@nuxt/content` v3 URLs cannot be resolved at runtime on serverless, so they will be missing from your sitemap. Prerender the sitemap to include them: add `nitro: { prerender: { routes: [\'/sitemap.xml\'] } }` (or `/sitemap_index.xml` for multi-sitemaps). See https://nuxtseo.com/sitemap/guides/content')
-      }
       if (config.strictNuxtContentPaths) {
         logger.warn('You have set `strictNuxtContentPaths: true` but are using @nuxt/content v3. This is not required, please remove it.')
       }

--- a/src/module.ts
+++ b/src/module.ts
@@ -543,6 +543,15 @@ export default defineNuxtModule<ModuleOptions>({
         route: '/__sitemap__/nuxt-content-urls.json',
         handler: resolve('./runtime/server/routes/__sitemap__/nuxt-content-urls-v3'),
       })
+      // On serverless (functions) @nuxt/content v3 restores its SQLite DB at runtime from a
+      // prerendered sql_dump.txt that lives in the CDN output, not in the function bundle, so a
+      // runtime content query 404s and yields no URLs (it degrades gracefully but silently).
+      // The query only succeeds at build, where content uses its local DB, so the sitemap must be
+      // prerendered to capture content URLs. Warn at build when we can detect the broken combo.
+      const serverlessPresets = new Set(['vercel', 'netlify', 'cloudflare', 'cloudflare-pages', 'cloudflare-module', 'aws-lambda', 'aws-amplify', 'firebase', 'edgio', 'zeabur'])
+      if (!prerenderSitemap && serverlessPresets.has(resolveNitroPreset())) {
+        logger.warn('`@nuxt/content` v3 URLs cannot be resolved at runtime on serverless, so they will be missing from your sitemap. Prerender the sitemap to include them: add `nitro: { prerender: { routes: [\'/sitemap.xml\'] } }` (or `/sitemap_index.xml` for multi-sitemaps). See https://nuxtseo.com/sitemap/guides/content')
+      }
       if (config.strictNuxtContentPaths) {
         logger.warn('You have set `strictNuxtContentPaths: true` but are using @nuxt/content v3. This is not required, please remove it.')
       }

--- a/src/runtime/server/routes/__sitemap__/nuxt-content-urls-v3.ts
+++ b/src/runtime/server/routes/__sitemap__/nuxt-content-urls-v3.ts
@@ -39,12 +39,12 @@ export default defineEventHandler(async (e) => {
           return { collection, entries: filter ? results.filter(filter) : results }
         })
         .catch((err) => {
-          // On serverless (Vercel/Netlify functions) @nuxt/content v3 restores its
-          // SQLite DB at runtime from a prerendered sql_dump.txt that isn't bundled
-          // into the function, so this query can throw. Degrade to an empty source
-          // for this collection instead of 500ing the entire sitemap. The query only
-          // succeeds at build, so prerender the sitemap to include these entries.
-          console.error(`[@nuxtjs/sitemap] Failed to query @nuxt/content collection "${collection}" for the sitemap; returning no URLs for it. On serverless the content DB is restored at runtime from a prerendered dump that isn't bundled into the function. Prerender the sitemap to include these URLs.`, err)
+          // On serverless (Vercel/Netlify functions) @nuxt/content restores its SQLite DB at
+          // runtime from a prerendered sql_dump.txt, but that asset is served from the static
+          // output and isn't readable inside the function, so the restore yields an empty DB and
+          // this query throws (see https://github.com/nuxt/content/issues/3805). Degrade to an
+          // empty source for this collection instead of 500ing the whole sitemap.
+          console.error(`[@nuxtjs/sitemap] Couldn't query @nuxt/content collection "${collection}" for the sitemap, so its URLs will be missing. On serverless the content DB is restored from a prerendered sql_dump.txt that isn't readable inside the function (nuxt/content#3805). Fix: prerender the sitemap so content URLs resolve at build, or configure a runtime database (D1/Turso/Postgres).`, err)
           return { collection, entries: [] as ContentEntry[] }
         }),
     )

--- a/src/runtime/server/routes/__sitemap__/nuxt-content-urls-v3.ts
+++ b/src/runtime/server/routes/__sitemap__/nuxt-content-urls-v3.ts
@@ -37,6 +37,15 @@ export default defineEventHandler(async (e) => {
           // apply runtime filter if available
           const filter = filters?.get(collection)
           return { collection, entries: filter ? results.filter(filter) : results }
+        })
+        .catch((err) => {
+          // On serverless (Vercel/Netlify functions) @nuxt/content v3 restores its
+          // SQLite DB at runtime from a prerendered sql_dump.txt that isn't bundled
+          // into the function, so this query can throw. Degrade to an empty source
+          // for this collection instead of 500ing the entire sitemap. Prerender the
+          // sitemap (or content URLs) to include these entries on serverless.
+          console.error(`[@nuxtjs/sitemap] Failed to query @nuxt/content collection "${collection}" for the sitemap; returning no URLs for it. On serverless the content DB is restored at runtime from a prerendered dump that may not be bundled into the function.`, err)
+          return { collection, entries: [] as ContentEntry[] }
         }),
     )
   }

--- a/src/runtime/server/routes/__sitemap__/nuxt-content-urls-v3.ts
+++ b/src/runtime/server/routes/__sitemap__/nuxt-content-urls-v3.ts
@@ -42,9 +42,9 @@ export default defineEventHandler(async (e) => {
           // On serverless (Vercel/Netlify functions) @nuxt/content v3 restores its
           // SQLite DB at runtime from a prerendered sql_dump.txt that isn't bundled
           // into the function, so this query can throw. Degrade to an empty source
-          // for this collection instead of 500ing the entire sitemap. Prerender the
-          // sitemap (or content URLs) to include these entries on serverless.
-          console.error(`[@nuxtjs/sitemap] Failed to query @nuxt/content collection "${collection}" for the sitemap; returning no URLs for it. On serverless the content DB is restored at runtime from a prerendered dump that may not be bundled into the function.`, err)
+          // for this collection instead of 500ing the entire sitemap. The query only
+          // succeeds at build, so prerender the sitemap to include these entries.
+          console.error(`[@nuxtjs/sitemap] Failed to query @nuxt/content collection "${collection}" for the sitemap; returning no URLs for it. On serverless the content DB is restored at runtime from a prerendered dump that isn't bundled into the function. Prerender the sitemap to include these URLs.`, err)
           return { collection, entries: [] as ContentEntry[] }
         }),
     )


### PR DESCRIPTION
### 🔗 Linked issue

Related to harlan-zw/nuxt-seo#541
Upstream root cause: nuxt/content#3805

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`/__sitemap__/nuxt-content-urls.json` 500s in production on serverless (Vercel/Netlify) while working in dev and on node-server. One reporter has no i18n, so it is the content source, not i18n.

The cause is upstream in `@nuxt/content`. `queryCollection` restores its SQLite DB at runtime from `/__nuxt_content/<collection>/sql_dump.txt`. Content marks that route `prerender: true` for every preset, then only the `aws-amplify` preset reverts it to `false` so its bundled `database-handler` serves the dump live inside the function. The `vercel` and `netlify` presets inherit the bundled dump and handler from the `node` parent but never revert the prerender rule, so on those platforms the dump is served as a static asset the function can't read. The restore yields an empty DB, the table is missing, and the query throws. Verified against the failure chain logged in nuxt/content#3804 (`readAll '/public/.../sql_dump.txt'` -> `Failed to fetch compressed dump` -> `no such table`).

This PR is the module-side containment: each per-collection query gets a `.catch` so one failing collection returns no URLs instead of 500ing the whole sitemap. The error message names the cause, links nuxt/content#3805, and gives both fixes (prerender the sitemap so content URLs resolve at build, or configure a runtime database). The preset fix itself belongs upstream in `@nuxt/content`.