### PR TITLE
fix(i18n): avoid locale sitemap prefix collisions

### DIFF
--- a/src/runtime/server/sitemap/builder/sitemap.ts
+++ b/src/runtime/server/sitemap/builder/sitemap.ts
@@ -18,7 +18,7 @@ import { resolveSitePath } from 'nuxt-site-config/urls'
 import { joinURL, withHttps } from 'ufo'
 // @ts-expect-error virtual module
 import staticConfig from '#sitemap-virtual/static-config.mjs'
-import { applyDynamicParams, createPathFilter, findPageMapping, logger, splitForLocales } from '../../../utils-pure'
+import { applyDynamicParams, createPathFilter, findPageMapping, logger, resolveI18nSitemapLocaleKey, splitForLocales } from '../../../utils-pure'
 import { preNormalizeEntry } from '../urlset/normalise'
 import { sortInPlace } from '../urlset/sort'
 import { childSitemapSources, globalSitemapSources, resolveSitemapSources } from '../urlset/sources'
@@ -280,13 +280,14 @@ export async function buildResolvedSitemapUrls(
   await nitro?.hooks.callHook('sitemap:input', resolvedCtx)
   const enhancedUrls = resolveSitemapEntries(effectiveSitemap, resolvedCtx.urls, { autoI18n, isI18nMapped }, resolvers, useRuntimeConfig().app.baseURL)
 
+  const localeSitemapKeys = isI18nMapped && autoI18n ? autoI18n.locales.map(l => l._sitemap) : []
   if (isMultiSitemap) {
     const sitemapNames = Object.keys(sitemaps).filter(k => k !== 'index')
     // @ts-expect-error loose typing
     const warnedSitemaps = nitro?._sitemapWarnedSitemaps || new Set<string>()
     for (const e of enhancedUrls) {
       const hasMatchingSitemap = typeof e._sitemap === 'string'
-        && (sitemapNames.includes(e._sitemap) || (isI18nMapped && sitemapNames.some(name => name.startsWith(`${e._sitemap}-`))))
+        && (sitemapNames.includes(e._sitemap) || (isI18nMapped && sitemapNames.some(name => resolveI18nSitemapLocaleKey(name, localeSitemapKeys) === e._sitemap)))
       if (typeof e._sitemap === 'string' && !hasMatchingSitemap) {
         if (!warnedSitemaps.has(e._sitemap)) {
           warnedSitemaps.add(e._sitemap)
@@ -306,7 +307,14 @@ export async function buildResolvedSitemapUrls(
     if (isMultiSitemap && e._sitemap && matchName) {
       if (isChunked)
         return e._sitemap === matchName
-      return e._sitemap === matchName || (isI18nMapped && matchName.startsWith(`${e._sitemap}-`))
+      if (e._sitemap === matchName)
+        return true
+      // i18n-mapped custom sitemaps are named `<localeSitemap>-<name>`; resolve the matchName
+      // back to its locale key (longest match) so prefix-sharing locales don't collide,
+      // e.g. a `zh` URL must not land in the `zh-Hant` sitemap.
+      if (isI18nMapped)
+        return e._sitemap === resolveI18nSitemapLocaleKey(matchName, localeSitemapKeys)
+      return false
     }
     return true
   })

--- a/src/runtime/utils-pure.ts
+++ b/src/runtime/utils-pure.ts
@@ -54,6 +54,26 @@ export function splitForLocales(path: string, locales: string[]): [string | null
   return [null, path]
 }
 
+/**
+ * Resolve which locale a multi-sitemap name belongs to.
+ *
+ * i18n-mapped sitemaps are named either `<localeSitemap>` (default) or
+ * `<localeSitemap>-<name>` (custom sitemaps). Locale `_sitemap` keys can share a
+ * prefix (e.g. `zh` and `zh-Hant`), so a naive `name.startsWith(`${key}-`)` check
+ * collides: `zh-Hant` would match the `zh` locale. Resolve by the longest matching
+ * key to disambiguate.
+ */
+export function resolveI18nSitemapLocaleKey(sitemapName: string, localeSitemapKeys: string[]): string | null {
+  let best: string | null = null
+  for (const key of localeSitemapKeys) {
+    if (sitemapName === key || sitemapName.startsWith(`${key}-`)) {
+      if (best === null || key.length > best.length)
+        best = key
+    }
+  }
+  return best
+}
+
 const StringifiedRegExpPattern = /\/(.*?)\/([gimsuy]*)$/
 
 /**

--- a/test/e2e/issues/621-locale-prefix-collision.test.ts
+++ b/test/e2e/issues/621-locale-prefix-collision.test.ts
@@ -1,0 +1,36 @@
+import { createResolver } from '@nuxt/kit'
+import { $fetch, setup } from '@nuxt/test-utils'
+import { describe, expect, it } from 'vitest'
+
+const { resolve } = createResolver(import.meta.url)
+
+// https://github.com/nuxt-modules/sitemap/issues/621
+await setup({
+  rootDir: resolve('../../fixtures/issue-621'),
+  server: true,
+})
+
+// extract the primary `<loc>` entries (ignoring hreflang alternative links,
+// which legitimately reference the sibling locale's URLs)
+function locs(xml: string): string[] {
+  return [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map(m => m[1]!)
+}
+
+describe('issue #621 - locale sitemap prefix collisions', () => {
+  it('zh-Hant sitemap only lists /tw URLs, not /zh URLs', async () => {
+    const entries = locs(await $fetch('/__sitemap__/zh-Hant.xml'))
+    expect(entries).toContain('https://nuxtseo.com/tw/about')
+    expect(entries).toContain('https://nuxtseo.com/tw/contact')
+    // the bug: /zh URLs (sitemap `zh`) leaked into the `zh-Hant` sitemap
+    expect(entries).not.toContain('https://nuxtseo.com/zh/about')
+    expect(entries).not.toContain('https://nuxtseo.com/zh/contact')
+  }, 60000)
+
+  it('zh sitemap only lists /zh URLs', async () => {
+    const entries = locs(await $fetch('/__sitemap__/zh.xml'))
+    expect(entries).toContain('https://nuxtseo.com/zh/about')
+    expect(entries).toContain('https://nuxtseo.com/zh/contact')
+    expect(entries).not.toContain('https://nuxtseo.com/tw/about')
+    expect(entries).not.toContain('https://nuxtseo.com/tw/contact')
+  }, 60000)
+}, 60000)

--- a/test/fixtures/issue-621/nuxt.config.ts
+++ b/test/fixtures/issue-621/nuxt.config.ts
@@ -1,0 +1,48 @@
+import NuxtSitemap from '../../../src/module'
+
+// https://github.com/nuxt-modules/sitemap/issues/621
+// Two locales where one `language` tag is a prefix of the other:
+//   zh -> language `zh`,      URLs at /zh/...
+//   tw -> language `zh-Hant`, URLs at /tw/...
+// Each per-locale sitemap (`zh` / `zh-Hant`) must only contain its own URLs.
+export default defineNuxtConfig({
+  modules: [
+    NuxtSitemap,
+    '@nuxtjs/i18n',
+  ],
+
+  site: {
+    url: 'https://nuxtseo.com',
+  },
+
+  compatibilityDate: '2024-07-22',
+
+  i18n: {
+    baseUrl: 'https://nuxtseo.com',
+    detectBrowserLanguage: false,
+    defaultLocale: 'en',
+    strategy: 'prefix_except_default',
+    locales: [
+      {
+        code: 'en',
+        language: 'en-US',
+      },
+      {
+        code: 'zh',
+        language: 'zh',
+      },
+      {
+        code: 'tw',
+        language: 'zh-Hant',
+      },
+    ],
+  },
+
+  sitemap: {
+    excludeAppSources: true,
+    sources: ['/__sitemap'],
+    autoLastmod: false,
+    credits: false,
+    debug: true,
+  },
+})

--- a/test/fixtures/issue-621/pages/index.vue
+++ b/test/fixtures/issue-621/pages/index.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    <h1>Home</h1>
+  </div>
+</template>

--- a/test/fixtures/issue-621/server/routes/__sitemap.ts
+++ b/test/fixtures/issue-621/server/routes/__sitemap.ts
@@ -1,0 +1,12 @@
+import { defineSitemapEventHandler } from '#imports'
+
+// Dynamic URLs from a custom source, each tagged with its locale's `language`
+// tag via `_sitemap`, exactly as described in issue #621.
+export default defineSitemapEventHandler(() => {
+  return [
+    { loc: '/zh/about', _sitemap: 'zh' },
+    { loc: '/zh/contact', _sitemap: 'zh' },
+    { loc: '/tw/about', _sitemap: 'zh-Hant' },
+    { loc: '/tw/contact', _sitemap: 'zh-Hant' },
+  ]
+})

--- a/test/unit/resolveI18nSitemapLocaleKey.test.ts
+++ b/test/unit/resolveI18nSitemapLocaleKey.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { resolveI18nSitemapLocaleKey } from '../../src/runtime/utils-pure'
+
+describe('resolveI18nSitemapLocaleKey', () => {
+  // issue #621: one locale `_sitemap` is a prefix of another (zh / zh-Hant)
+  const prefixSharing = ['zh', 'zh-Hant']
+
+  it('matches a default locale sitemap exactly', () => {
+    expect(resolveI18nSitemapLocaleKey('zh', prefixSharing)).toBe('zh')
+    expect(resolveI18nSitemapLocaleKey('zh-Hant', prefixSharing)).toBe('zh-Hant')
+  })
+
+  it('does not let a prefix-sharing locale steal another locale sitemap', () => {
+    // `zh-Hant` must resolve to the `zh-Hant` locale, NOT `zh`
+    expect(resolveI18nSitemapLocaleKey('zh-Hant', prefixSharing)).not.toBe('zh')
+  })
+
+  it('matches custom i18n sitemaps via longest locale key', () => {
+    // `<localeSitemap>-<name>` naming
+    expect(resolveI18nSitemapLocaleKey('zh-pages', prefixSharing)).toBe('zh')
+    expect(resolveI18nSitemapLocaleKey('zh-Hant-pages', prefixSharing)).toBe('zh-Hant')
+  })
+
+  it('handles en / en-US prefix collisions', () => {
+    const keys = ['en', 'en-US']
+    expect(resolveI18nSitemapLocaleKey('en', keys)).toBe('en')
+    expect(resolveI18nSitemapLocaleKey('en-US', keys)).toBe('en-US')
+    expect(resolveI18nSitemapLocaleKey('en-posts', keys)).toBe('en')
+    expect(resolveI18nSitemapLocaleKey('en-US-posts', keys)).toBe('en-US')
+  })
+
+  it('returns null when no locale key matches (non-i18n sitemap)', () => {
+    expect(resolveI18nSitemapLocaleKey('custom', prefixSharing)).toBeNull()
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #621

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

When two i18n locales had `_sitemap` keys (their `language` tag) where one was a prefix of the other, for example `zh` (`/zh/...`) and `zh-Hant` (`/tw/...`), URLs for the shorter key leaked into the longer key's sitemap. The cause was the `matchName.startsWith(`${e._sitemap}-`)` check in `buildResolvedSitemapUrls`, where `zh-Hant`.startsWith(`zh-`) matched entries tagged `_sitemap: 'zh'`.

This adds `resolveI18nSitemapLocaleKey`, which maps a sitemap name back to its locale key by longest match, so `zh-Hant` resolves to the `zh-Hant` locale rather than `zh`. The same logic is applied to both the warning check and the filter, and covers the custom `<localeSitemap>-<name>` sitemap naming too. Verified by a unit test for the resolver and an e2e fixture (`issue-621`) asserting each locale sitemap only lists its own `<loc>` entries.