### PR TITLE
fix: include prerendered pages with no `_sitemap` (#624)

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -887,10 +887,18 @@ export default defineNuxtModule<ModuleOptions>({
       const prerenderUrlsFinal = [
         ...prerenderedRoutes
           .filter(isValidPrerenderRoute)
-          // fall back to the route itself when prerender:generate left no `_sitemap`
-          // (empty contents / redirect HTML / nitro versions without `route.contents`),
-          // otherwise the route is dropped here yet still deduped out of the page source (#624)
-          .map(r => r._sitemap || { loc: r.route })
+          .map((r) => {
+            if (r._sitemap)
+              return r._sitemap
+            // prerender:generate left no `_sitemap` (empty contents / nitro versions
+            // without `route.contents`): fall back to the route itself, otherwise it is
+            // dropped here yet still deduped out of the page source (#624). Skip internal
+            // routes which are extensionless text/html but not real pages (same exclusion
+            // as `filterForValidPage`).
+            if (r.route.startsWith('/api/') || r.route.startsWith('/_'))
+              return undefined
+            return { loc: r.route }
+          })
           .filter(entry => entry && (typeof entry === 'string' || entry._sitemap !== false)),
       ]
       if (config.debug) {

--- a/src/module.ts
+++ b/src/module.ts
@@ -887,7 +887,10 @@ export default defineNuxtModule<ModuleOptions>({
       const prerenderUrlsFinal = [
         ...prerenderedRoutes
           .filter(isValidPrerenderRoute)
-          .map(r => r._sitemap)
+          // fall back to the route itself when prerender:generate left no `_sitemap`
+          // (empty contents / redirect HTML / nitro versions without `route.contents`),
+          // otherwise the route is dropped here yet still deduped out of the page source (#624)
+          .map(r => r._sitemap || { loc: r.route })
           .filter(entry => entry && (typeof entry === 'string' || entry._sitemap !== false)),
       ]
       if (config.debug) {

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -74,8 +74,10 @@ export async function readSourcesFromFilesystem(filename) {
       // extract alternatives from the html
       if (!route.fileName?.endsWith('.html') || !html || ['/200.html', '/404.html'].includes(route.route))
         return
-      // ignore redirects
+      // ignore redirects: mark explicitly excluded so the module's missing-`_sitemap`
+      // fallback (`r._sitemap || { loc }`) doesn't resurface redirect routes (#624)
       if (NuxtRedirectHtmlRegex.test(html)) {
+        route._sitemap = { loc: route.route, _sitemap: false }
         return
       }
 

--- a/test/e2e/issues/624-prerendered-missing.test.ts
+++ b/test/e2e/issues/624-prerendered-missing.test.ts
@@ -39,5 +39,8 @@ describe.skipIf(process.env.CI)('issue-624', () => {
     // regression guard: a prerendered redirect (its `_sitemap` is also undefined)
     // must NOT be resurfaced by the missing-`_sitemap` fallback
     expect(sitemap).not.toContain('<loc>https://nuxtseo.com/old</loc>')
+    // regression guard: an internal extensionless text/html route with no `_sitemap`
+    // must NOT be synthesized by the fallback
+    expect(sitemap).not.toContain('<loc>https://nuxtseo.com/_internal</loc>')
   }, 1200000)
 })

--- a/test/e2e/issues/624-prerendered-missing.test.ts
+++ b/test/e2e/issues/624-prerendered-missing.test.ts
@@ -36,5 +36,8 @@ describe.skipIf(process.env.CI)('issue-624', () => {
     expect(sitemap).toContain('<loc>https://nuxtseo.com/prerendered/a</loc>')
     // bug: _sitemap stripped, page is silently dropped (issue #624)
     expect(sitemap).toContain('<loc>https://nuxtseo.com/prerendered/b</loc>')
+    // regression guard: a prerendered redirect (its `_sitemap` is also undefined)
+    // must NOT be resurfaced by the missing-`_sitemap` fallback
+    expect(sitemap).not.toContain('<loc>https://nuxtseo.com/old</loc>')
   }, 1200000)
 })

--- a/test/e2e/issues/624-prerendered-missing.test.ts
+++ b/test/e2e/issues/624-prerendered-missing.test.ts
@@ -1,0 +1,40 @@
+import { readFile } from 'node:fs/promises'
+import { buildNuxt, createResolver, loadNuxt } from '@nuxt/kit'
+import { describe, expect, it } from 'vitest'
+
+// https://github.com/nuxt-modules/sitemap/issues/624
+// A prerendered, indexable page whose `_sitemap` was never set ends up in
+// `allPrerenderedPaths` (removed from the page source) but is filtered out of
+// `prerenderUrlsFinal`, so it disappears from the sitemap entirely.
+describe.skipIf(process.env.CI)('issue-624', () => {
+  it('prerendered page without _sitemap is dropped from the sitemap', async () => {
+    process.env.NODE_ENV = 'production'
+    // @ts-expect-error untyped
+    process.env.prerender = true
+    process.env.NITRO_PRESET = 'static'
+    process.env.NUXT_PUBLIC_SITE_URL = 'https://nuxtseo.com'
+    const { resolve } = createResolver(import.meta.url)
+    const rootDir = resolve('../../fixtures/issue-624')
+    const nuxt = await loadNuxt({
+      rootDir,
+      overrides: {
+        nitro: {
+          preset: 'static',
+        },
+        _generate: true,
+      },
+    })
+    await buildNuxt(nuxt)
+
+    await new Promise(resolve => setTimeout(resolve, 1000))
+
+    const sitemap = (await readFile(resolve(rootDir, '.output/public/sitemap.xml'), 'utf-8')).replace(/lastmod>(.*?)</g, 'lastmod><')
+
+    console.log('\n===SITEMAP===\n', sitemap, '\n===END===\n')
+
+    // control: still has _sitemap, present in the sitemap
+    expect(sitemap).toContain('<loc>https://nuxtseo.com/prerendered/a</loc>')
+    // bug: _sitemap stripped, page is silently dropped (issue #624)
+    expect(sitemap).toContain('<loc>https://nuxtseo.com/prerendered/b</loc>')
+  }, 1200000)
+})

--- a/test/fixtures/issue-624/app.vue
+++ b/test/fixtures/issue-624/app.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    <NuxtPage />
+  </div>
+</template>

--- a/test/fixtures/issue-624/nuxt.config.ts
+++ b/test/fixtures/issue-624/nuxt.config.ts
@@ -32,6 +32,8 @@ export default defineNuxtConfig({
   routeRules: {
     '/prerendered/**': { prerender: true },
     '/ssr': { prerender: false },
+    // a prerendered redirect: must NOT appear in the sitemap
+    '/old': { prerender: true, redirect: '/prerendered/a' },
   },
 
   nitro: {

--- a/test/fixtures/issue-624/nuxt.config.ts
+++ b/test/fixtures/issue-624/nuxt.config.ts
@@ -16,8 +16,19 @@ export default defineNuxtConfig({
     function (_options, nuxt) {
       nuxt.hook('nitro:init', (nitro) => {
         nitro.hooks.hook('prerender:route', (route: any) => {
+          // simulate the upstream condition: a valid text/html prerender with no `_sitemap`
           if (route.route === '/prerendered/b')
             delete route._sitemap
+          // inject an internal, extensionless text/html route with no `_sitemap`:
+          // the fallback must not synthesize it into the sitemap
+          if (route.route === '/') {
+            nitro._prerenderedRoutes!.push({
+              route: '/_internal',
+              fileName: '/_internal.html',
+              // @ts-expect-error partial prerender route for the test
+              contentType: 'text/html',
+            })
+          }
         })
       })
     },

--- a/test/fixtures/issue-624/nuxt.config.ts
+++ b/test/fixtures/issue-624/nuxt.config.ts
@@ -1,0 +1,49 @@
+import NuxtSitemap from '../../../src/module'
+
+// https://github.com/nuxt-modules/sitemap/issues/624
+// Hybrid rendering. A prerendered page can end up in `nitro._prerenderedRoutes`
+// with a text/html contentType but WITHOUT a `_sitemap` property (the sitemap
+// module's `prerender:generate` hook early-returns for: empty `route.contents`,
+// redirect-style HTML, or nitro versions that don't expose contents in the hook).
+//
+// `/prerendered/a` keeps its `_sitemap` (control), `/prerendered/b` has it stripped
+// to reproduce the exact state the reporter observed: present in `allPrerenderedPaths`
+// (so it is removed from the page source) but dropped from `prerenderUrlsFinal`,
+// so it vanishes from the sitemap entirely.
+export default defineNuxtConfig({
+  modules: [
+    NuxtSitemap,
+    function (_options, nuxt) {
+      nuxt.hook('nitro:init', (nitro) => {
+        nitro.hooks.hook('prerender:route', (route: any) => {
+          if (route.route === '/prerendered/b')
+            delete route._sitemap
+        })
+      })
+    },
+  ],
+
+  site: {
+    url: 'https://nuxtseo.com',
+  },
+
+  compatibilityDate: '2025-01-15',
+
+  routeRules: {
+    '/prerendered/**': { prerender: true },
+    '/ssr': { prerender: false },
+  },
+
+  nitro: {
+    prerender: {
+      crawlLinks: true,
+      routes: ['/'],
+    },
+  },
+
+  sitemap: {
+    autoLastmod: false,
+    credits: false,
+    debug: true,
+  },
+})

--- a/test/fixtures/issue-624/pages/index.vue
+++ b/test/fixtures/issue-624/pages/index.vue
@@ -1,0 +1,8 @@
+<template>
+  <div>
+    <h1>Home</h1>
+    <NuxtLink to="/prerendered/a">a</NuxtLink>
+    <NuxtLink to="/prerendered/b">b</NuxtLink>
+    <NuxtLink to="/ssr">ssr</NuxtLink>
+  </div>
+</template>

--- a/test/fixtures/issue-624/pages/prerendered/a.vue
+++ b/test/fixtures/issue-624/pages/prerendered/a.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>Prerendered A</div>
+</template>

--- a/test/fixtures/issue-624/pages/prerendered/b.vue
+++ b/test/fixtures/issue-624/pages/prerendered/b.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>Prerendered B</div>
+</template>

--- a/test/fixtures/issue-624/pages/ssr.vue
+++ b/test/fixtures/issue-624/pages/ssr.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>SSR page</div>
+</template>


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #624

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

In `generateGlobalSources`, `prerenderUrlsFinal` is built with `.map(r => r._sitemap)` then filtered with `entry && …`, so any prerendered route whose `_sitemap` is `undefined` gets dropped. The same routes are still collected into `allPrerenderedPaths` (from `r.route`), which dedupes them out of the page source. The result: an indexable prerendered page is removed from the page source *and* filtered out of the prerender list, so it vanishes from the sitemap. This matches the report that `allPrerenderedPaths` contained the pages but `prerenderUrlsFinal` did not.

`_sitemap` ends up `undefined` when the `prerender:generate` hook (`src/prerender.ts`) early-returns without setting it: empty `route.contents`, redirect-style HTML, or a nitro version that doesn't expose `contents` in that hook. The route still lands in `_prerenderedRoutes` with a `text/html` contentType, so `isValidPrerenderRoute` passes.

Two changes:

1. `src/module.ts` falls back to `{ loc: r.route }` when `_sitemap` is missing, so the prerendered route still renders.
2. `src/prerender.ts` marks redirect HTML as `{ loc, _sitemap: false }` in the `prerender:generate` hook (same shape already used for noindex pages). Without this, the fallback in (1) would resurface redirect routes, whose `_sitemap` is also undefined. `routeRules` redirects are caught by the runtime route-rule filter (`server/sitemap/nitro.ts`), but a redirect issued from inside a component has no route rule and is only detectable from the prerendered HTML, which is exactly what the nitro hook sees.

Adds `test/fixtures/issue-624` + `test/e2e/issues/624-prerendered-missing.test.ts`: strips `_sitemap` from one prerendered page (control page keeps it), asserts both appear, and asserts a prerendered redirect stays out.