### PR TITLE
fix: decode discovered image HTML entities

### DIFF
--- a/src/utils/parseHtmlExtractSitemapMeta.ts
+++ b/src/utils/parseHtmlExtractSitemapMeta.ts
@@ -3,6 +3,32 @@ import type { ResolvedSitemapUrl, SitemapUrl, VideoEntry } from '../runtime/type
 import { parseURL } from 'ufo'
 import { ELEMENT_NODE, parse, walkSync } from 'ultrahtml'
 
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARACTERS_RE = /[\x00-\x1F\x7F-\x9F]/g
+const HTML_ENTITIES: Record<string, string> = {
+  amp: '&',
+  apos: '\'',
+  gt: '>',
+  lt: '<',
+  quot: '"',
+}
+const HTML_ENTITY_RE = /&(?:#(\d+)|#x([\da-f]+)|amp|apos|gt|lt|quot);/gi
+
+function decodeHtmlEntities(value: string): string {
+  return value.replace(HTML_ENTITY_RE, (match, decimal: string | undefined, hexadecimal: string | undefined) => {
+    if (decimal || hexadecimal) {
+      const entity = decimal || hexadecimal || ''
+      const codePoint = Number.parseInt(entity, decimal ? 10 : 16)
+      if (Number.isFinite(codePoint) && codePoint >= 0 && codePoint <= 0x10FFFF) {
+        return String.fromCodePoint(codePoint)
+      }
+      return match
+    }
+
+    return HTML_ENTITIES[match.slice(1, -1).toLowerCase()] || match
+  })
+}
+
 // Validation helpers
 function isValidUrl(url: string): boolean {
   if (!url || typeof url !== 'string')
@@ -33,8 +59,7 @@ function isValidString(value: unknown): value is string {
 function sanitizeString(value: unknown): string {
   if (!isValidString(value))
     return ''
-  // eslint-disable-next-line no-control-regex
-  return String(value).trim().replace(/[\x00-\x1F\x7F-\x9F]/g, '') // Remove control characters
+  return decodeHtmlEntities(String(value).trim().replace(CONTROL_CHARACTERS_RE, '')).replace(CONTROL_CHARACTERS_RE, '')
 }
 
 function isValidDate(dateString: string): boolean {

--- a/test/unit/parseHtmlExtractSitemapMeta.test.ts
+++ b/test/unit/parseHtmlExtractSitemapMeta.test.ts
@@ -96,6 +96,29 @@ describe('parseHtmlExtractSitemapMeta', () => {
     `)
   })
 
+  it('decodes HTML entities in image URLs', async () => {
+    const output = parseHtmlExtractSitemapMeta(`
+      <main>
+        <img src="/_vercel/image?url=%2Fimg%2Fportrait.webp&amp;w=768&amp;q=80" width="768" height="768" alt="portrait">
+      </main>
+    `, {
+      images: true,
+      resolveUrl(s) {
+        return s.startsWith('/') ? `https://example.com${s}` : s
+      },
+    })
+
+    expect(output).toMatchInlineSnapshot(`
+      {
+        "images": [
+          {
+            "loc": "https://example.com/_vercel/image?url=%2Fimg%2Fportrait.webp&w=768&q=80",
+          },
+        ],
+      }
+    `)
+  })
+
   it('video: ignores invalid markup', async () => {
     const mainTag = '<main>'
     const mainClosingTag = '</main>'


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #627

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`parseHtmlExtractSitemapMeta` now decodes HTML entities from extracted attributes before storing discovered image URLs. The XML builder still escapes output, so prerendered image URLs like `...?url=...&amp;w=...` emit one layer of `&amp;` in `<image:loc>` instead of `&amp;amp;`.