### PR TITLE
docs: document sitemap index lastmod

### DIFF
--- a/docs/content/1.guides/6.best-practices.md
+++ b/docs/content/1.guides/6.best-practices.md
@@ -6,6 +6,8 @@ navigation:
 relatedPages:
   - path: /docs/sitemap/advanced/loc-data
     title: Lastmod, Priority, and Changefreq
+  - path: /docs/sitemap/nitro-api/nitro-hooks
+    title: Nitro Hooks
   - path: /docs/sitemap/guides/submitting-sitemap
     title: Submitting Your Sitemap
   - path: /learn-seo/nuxt/controlling-crawlers
@@ -35,6 +37,16 @@ Learn more in [Google's sitemap lastmod documentation](https://developers.google
 
 Learn more in [Google's sitemap best practices](https://developers.google.com/search/blog/2023/06/sitemaps-lastmod-ping).
 
+## Set accurate sitemap index lastmod
+
+When using multiple sitemaps, each `<lastmod>` in `sitemap_index.xml` describes when the sitemap file in the same `<sitemap>` block changed. It does not describe the newest page listed in that file.
+
+Accurate dates allow crawlers to fetch only the sitemap files that changed. Leave the field out when you cannot produce a reliable date. Adding or removing a URL can change a sitemap file without changing the `lastmod` of any remaining page.
+
+`autoLastmod: true` gives every generated sitemap index entry the current timestamp. This is convenient, but it marks every sitemap as changed at once. For accurate per-sitemap dates, leave `autoLastmod` disabled and set them with the [`sitemap:index-resolved` hook](/docs/sitemap/nitro-api/nitro-hooks#sitemap-index-resolved).
+
+Learn more in [Google's sitemap index documentation](https://developers.google.com/search/docs/crawling-indexing/sitemaps/large-sitemaps#sitemap-index-reference).
+
 ## Use Zero Runtime when content only changes on deploy
 
 If your pages only change when you commit and deploy (not at runtime), you don't need runtime sitemap generation. Enable `zeroRuntime` to generate sitemaps at build time and remove ~50KB of sitemap code from your server bundle.
@@ -57,6 +69,7 @@ Learn more in the [Zero Runtime](/docs/sitemap/guides/zero-runtime) guide.
 
 ::checklist{id="sitemap-best-practices" title="Quick Checklist"}
 - Set meaningful lastmod dates based on content changes
+- Set sitemap index lastmod dates based on sitemap file changes
 - Skip changefreq and priority (ignored by search engines)
 - Enable zeroRuntime for static sites
 - Submit sitemap to Google Search Console

--- a/docs/content/1.guides/6.best-practices.md
+++ b/docs/content/1.guides/6.best-practices.md
@@ -43,6 +43,8 @@ When using multiple sitemaps, each `<lastmod>` in `sitemap_index.xml` describes 
 
 Accurate dates allow crawlers to fetch only the sitemap files that changed. Leave the field out when you cannot produce a reliable date. Adding or removing a URL can change a sitemap file without changing the `lastmod` of any remaining page.
 
+See the [`sitemap:index-resolved` recipe](/docs/sitemap/nitro-api/nitro-hooks#sitemap-index-resolved) for setting these dates from your database or sitemap metadata.
+
 Learn more in [Google's sitemap index documentation](https://developers.google.com/search/docs/crawling-indexing/sitemaps/large-sitemaps#sitemap-index-reference).
 
 ## Use Zero Runtime when content only changes on deploy

--- a/docs/content/1.guides/6.best-practices.md
+++ b/docs/content/1.guides/6.best-practices.md
@@ -39,11 +39,9 @@ Learn more in [Google's sitemap best practices](https://developers.google.com/se
 
 ## Set accurate sitemap index lastmod
 
-When using multiple sitemaps, each `<lastmod>` in `sitemap_index.xml` describes when the sitemap file in the same `<sitemap>` block changed. It does not describe the newest page listed in that file.
+When using multiple sitemaps, each `<lastmod>` in `sitemap_index.xml` describes when the sitemap file in the same `<sitemap>` block changed. Page modification dates belong to the URL entries inside that file.
 
 Accurate dates allow crawlers to fetch only the sitemap files that changed. Leave the field out when you cannot produce a reliable date. Adding or removing a URL can change a sitemap file without changing the `lastmod` of any remaining page.
-
-`autoLastmod: true` gives every generated sitemap index entry the current timestamp. This is convenient, but it marks every sitemap as changed at once. For accurate per-sitemap dates, leave `autoLastmod` disabled and set them with the [`sitemap:index-resolved` hook](/docs/sitemap/nitro-api/nitro-hooks#sitemap-index-resolved).
 
 Learn more in [Google's sitemap index documentation](https://developers.google.com/search/docs/crawling-indexing/sitemaps/large-sitemaps#sitemap-index-reference).
 

--- a/docs/content/2.advanced/3.chunking-sources.md
+++ b/docs/content/2.advanced/3.chunking-sources.md
@@ -42,6 +42,28 @@ This generates:
 ...
 ```
 
+## Controlling URL Order
+
+By default, `sortEntries: true` sorts all resolved URLs by `loc` before splitting them into chunks. The order returned by your source is not preserved.
+
+Set `sortEntries: false` when chunk boundaries should follow your source order:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  sitemap: {
+    sortEntries: false,
+    sitemaps: {
+      posts: {
+        sources: ['/api/posts'],
+        chunks: true,
+      }
+    }
+  }
+})
+```
+
+Keep the source order deterministic. Inserting or removing an entry before an existing chunk boundary moves URLs between sitemap files, so update the [sitemap index `lastmod`](/docs/sitemap/guides/best-practices#set-accurate-sitemap-index-lastmod) for every file that changed.
+
 ## Chunk Size Options
 
 Configure chunk sizes using different approaches:

--- a/docs/content/3.api/0.config.md
+++ b/docs/content/3.api/0.config.md
@@ -49,7 +49,9 @@ This will only do anything when using multiple sitemaps.
 
 - Default: `false`{lang="ts"}
 
-Sets the current date as the default `lastmod` for all entries that don't already have one.
+Sets the current date as the default `lastmod` for URL entries that don't already have one.
+
+When using multiple sitemaps, this also sets the current timestamp on every generated sitemap index entry. These timestamps do not track when each sitemap file changed. For accurate per-sitemap dates, leave this disabled and use the [`sitemap:index-resolved` hook](/docs/sitemap/nitro-api/nitro-hooks#sitemap-index-resolved).
 
 ## `sitemaps: boolean | Record<string, SitemapConfig> & { index?: (string | SitemapIndexEntry)[] }`
 

--- a/docs/content/3.api/0.config.md
+++ b/docs/content/3.api/0.config.md
@@ -49,9 +49,7 @@ This will only do anything when using multiple sitemaps.
 
 - Default: `false`{lang="ts"}
 
-Sets the current date as the default `lastmod` for URL entries that don't already have one.
-
-When using multiple sitemaps, this also sets the current timestamp on every generated sitemap index entry. These timestamps do not track when each sitemap file changed. For accurate per-sitemap dates, leave this disabled and use the [`sitemap:index-resolved` hook](/docs/sitemap/nitro-api/nitro-hooks#sitemap-index-resolved).
+Sets the current date as the default `lastmod` for all entries that don't already have one.
 
 ## `sitemaps: boolean | Record<string, SitemapConfig> & { index?: (string | SitemapIndexEntry)[] }`
 

--- a/docs/content/4.nitro-api/nitro-hooks.md
+++ b/docs/content/4.nitro-api/nitro-hooks.md
@@ -74,7 +74,7 @@ export default defineNitroPlugin((nitroApp) => {
 
 Triggered once the final structure of the sitemap index is generated, provides the sitemaps as objects.
 
-In a sitemap index, `lastmod` is the modification time of the sitemap file, not the newest page inside it. Use this hook to add accurate dates to generated sitemap entries. For chunked sitemaps, fetch the metadata in one query and map it by filename:
+In a sitemap index, `lastmod` records when the sitemap file changed. Page modification dates belong to the URL entries inside that file. Use this hook to add accurate dates to generated sitemap entries. For chunked sitemaps, fetch the metadata in one query and map it by filename:
 
 ```ts [server/plugins/sitemap.ts]
 import { defineNitroPlugin } from 'nitropack/runtime'

--- a/docs/content/4.nitro-api/nitro-hooks.md
+++ b/docs/content/4.nitro-api/nitro-hooks.md
@@ -74,15 +74,39 @@ export default defineNitroPlugin((nitroApp) => {
 
 Triggered once the final structure of the sitemap index is generated, provides the sitemaps as objects.
 
+In a sitemap index, `lastmod` is the modification time of the sitemap file, not the newest page inside it. Use this hook to add accurate dates to generated sitemap entries. For chunked sitemaps, fetch the metadata in one query and map it by filename:
+
 ```ts [server/plugins/sitemap.ts]
 import { defineNitroPlugin } from 'nitropack/runtime'
 
 export default defineNitroPlugin((nitroApp) => {
-  nitroApp.hooks.hook('sitemap:index-resolved', async (ctx) => {
-    // add a new sitemap to the index
-    ctx.sitemaps.push({
+  nitroApp.hooks.hook('sitemap:index-resolved', async ({ sitemaps }) => {
+    // Your application should return W3C date strings keyed by sitemap filename.
+    const lastmodByFile = await getSitemapLastmods()
+
+    for (const entry of sitemaps) {
+      const filename = new URL(entry.sitemap).pathname.split('/').pop()!
+      const lastmod = lastmodByFile[filename]
+
+      if (lastmod)
+        entry.lastmod = lastmod
+    }
+  })
+})
+```
+
+Avoid fetching the generated sitemap files from this hook. Query the database or metadata store that records when they changed instead.
+
+The hook can also add another sitemap to the index:
+
+```ts [server/plugins/sitemap.ts]
+import { defineNitroPlugin } from 'nitropack/runtime'
+
+export default defineNitroPlugin((nitroApp) => {
+  nitroApp.hooks.hook('sitemap:index-resolved', ({ sitemaps }) => {
+    sitemaps.push({
       sitemap: 'https://mysite.com/my-sitemap.xml',
-      lastmod: new Date().toISOString(),
+      lastmod: '2026-07-20',
     })
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue.

### ❓ Type of change

- [x] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Document the sitemap index `lastmod` semantics and add a `sitemap:index-resolved` recipe for generated and chunked sitemaps. The chunking guide also explains how `sortEntries: false` keeps the source order before chunk boundaries are calculated.