### PR TITLE
fix: decompress gzipped sitemaps in the production debug endpoint

### DIFF
--- a/src/runtime/server/routes/__sitemap__/debug-production.ts
+++ b/src/runtime/server/routes/__sitemap__/debug-production.ts
@@ -1,6 +1,7 @@
 import type { SitemapWarning } from '@nuxtjs/sitemap/utils'
 import { isSitemapIndex, parseSitemapIndex, parseSitemapXml } from '@nuxtjs/sitemap/utils'
 import { defineEventHandler, getQuery } from 'h3'
+import { decodeSitemapResponseBytes } from '../../sitemap/urlset/gzip'
 
 export interface ProductionSitemapEntry {
   loc: string
@@ -20,12 +21,15 @@ export interface ProductionDebugResponse {
 
 async function fetchXml(url: string): Promise<string> {
   const response = await fetch(url, {
-    headers: { Accept: 'application/xml, text/xml' },
+    headers: { Accept: 'application/xml, text/xml, application/gzip' },
     signal: AbortSignal.timeout(15000),
   })
   if (!response.ok)
     throw new Error(`HTTP ${response.status}: ${response.statusText}`)
-  return response.text()
+  // Fetch as bytes so a gzipped sitemap (`.xml.gz`, or gzip served without a
+  // Content-Encoding header) decompresses instead of decoding into mojibake —
+  // same handling as fetchDataSource in the urlset pipeline.
+  return decodeSitemapResponseBytes(new Uint8Array(await response.arrayBuffer()))
 }
 
 export default defineEventHandler(async (e): Promise<ProductionDebugResponse | Record<string, any>> => {


### PR DESCRIPTION
### 🔗 Linked issue

Follow-up to #637, which flagged this endpoint as having the same gzip gap.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`fetchXml` in `debug-production.ts` read response bodies as text, so pointing the debug endpoint at a `.xml.gz` sitemap (or a server sending raw gzip bytes without `Content-Encoding`) produced mojibake that failed parsing. It now fetches bytes and runs them through `decodeSitemapResponseBytes`, the helper #637 added for `fetchDataSource`. The decode logic itself is already covered by `test/unit/fetchDataSourceGzip.test.ts`.