### PR TITLE
fix(types): register augments for Nitro projects

### DIFF
--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -1,0 +1,31 @@
+import { addTypeTemplate, hasNuxtModule } from '@nuxt/kit'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { registerTypeTemplates } from './templates'
+
+vi.mock('@nuxt/kit', () => ({
+  addTemplate: vi.fn(),
+  addTypeTemplate: vi.fn(),
+  hasNuxtModule: vi.fn(),
+}))
+
+describe('registerTypeTemplates', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(hasNuxtModule).mockReturnValue(false)
+  })
+
+  it('registers augmentations in Nitro, node, and Nuxt contexts', () => {
+    registerTypeTemplates()
+
+    expect(addTypeTemplate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filename: 'types/nuxt-sitemap-augments.d.ts',
+      }),
+      {
+        nitro: true,
+        node: true,
+        nuxt: true,
+      },
+    )
+  })
+})

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -70,6 +70,10 @@ declare module 'nuxt/app' {
 export {}
 `
     },
+  }, {
+    nitro: true,
+    node: true,
+    nuxt: true,
   })
 
   // Type definitions for virtual modules


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #640

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Nuxt registered `nuxt-sitemap-augments.d.ts` only in the app type context, leaving sitemap Nitro hook callbacks untyped in project-reference configs. Register the template for Nitro and node type contexts, and cover the context flags with a unit regression test.
