### PR TITLE
test: wait for render-plan cache before asserting streaming cache hit

### DIFF
--- a/test/e2e/single/streaming.test.ts
+++ b/test/e2e/single/streaming.test.ts
@@ -55,6 +55,14 @@ describe('experimental sitemap streaming', () => {
   })
 
   it('compresses without buffering the stream', async () => {
+    await vi.waitFor(() => {
+      const cached = fs.readdirSync(cacheDir, { recursive: true })
+        .map(file => path.join(cacheDir, file))
+        .filter(file => fs.statSync(file).isFile())
+        .some(file => fs.readFileSync(file, 'utf8').includes('page-1999'))
+      expect(cached).toBe(true)
+    })
+
     const response = await fetch('/__sitemap__/pages.xml', {
       headers: { 'Accept-Encoding': 'deflate;q=0.5, gzip;q=1' },
     })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

noticed in https://github.com/nuxt/ecosystem-ci/actions/runs/30006993397/job/89205271354

issue is that nitro is non-blocking on cache writes so it's possible (for fast requests) to bypass a cache which hasn't yet been written