### PR TITLE
fix: expose configured sources during prerender

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -1064,23 +1064,17 @@ export async function readSourcesFromFilesystem() {
 `
       }
 
-      // Skip virtual templates when prerendering - sources are written to filesystem instead
-      // In dev mode, always generate sources even if prerenderSitemap is true (e.g. zeroRuntime)
-      if (prerenderSitemap && !nuxt.options.dev) {
-        nitroConfig.virtual['#sitemap-virtual/global-sources.mjs'] = `export const sources = []`
-        nitroConfig.virtual[`#sitemap-virtual/child-sources.mjs`] = `export const sources = {}`
+      // Virtual templates provide the initial build-time sources. During
+      // prerender, the filesystem handoff replaces them with the final sources
+      // after all routes have been crawled.
+      nitroConfig.virtual['#sitemap-virtual/global-sources.mjs'] = async () => {
+        const globalSources = await generateGlobalSources()
+        return `export const sources = ${JSON.stringify(globalSources, null, 4)}`
       }
-      else {
-        // Virtual templates generate sources data - will be cached in storage on first use
-        nitroConfig.virtual['#sitemap-virtual/global-sources.mjs'] = async () => {
-          const globalSources = await generateGlobalSources()
-          return `export const sources = ${JSON.stringify(globalSources, null, 4)}`
-        }
 
-        nitroConfig.virtual![`#sitemap-virtual/child-sources.mjs`] = async () => {
-          const childSources = await generateChildSources()
-          return `export const sources = ${JSON.stringify(childSources, null, 4)}`
-        }
+      nitroConfig.virtual![`#sitemap-virtual/child-sources.mjs`] = async () => {
+        const childSources = await generateChildSources()
+        return `export const sources = ${JSON.stringify(childSources, null, 4)}`
       }
     })
 

--- a/src/runtime/server/sitemap/builder/sitemap-index.ts
+++ b/src/runtime/server/sitemap/builder/sitemap-index.ts
@@ -133,8 +133,7 @@ async function buildSitemapIndexInternal(resolvers: NitroUrlResolvers, runtimeCo
 
 export async function buildSitemapIndex(resolvers: NitroUrlResolvers, runtimeConfig: ModuleRuntimeConfig, nitro?: NitroApp) {
   // Check if should use cached version.
-  // Skip caching during prerender: sources are written to disk by `prerender:done`, so
-  // an early crawl would otherwise poison the cache with an empty result.
+  // Skip caching during prerender so the final filesystem source handoff is visible.
   if (!import.meta.dev && !import.meta.prerender && typeof runtimeConfig.cacheMaxAgeSeconds === 'number' && runtimeConfig.cacheMaxAgeSeconds > 0 && resolvers.event) {
     return buildSitemapIndexCached(resolvers.event, resolvers, runtimeConfig, nitro)
   }

--- a/src/runtime/server/sitemap/builder/sitemap.ts
+++ b/src/runtime/server/sitemap/builder/sitemap.ts
@@ -359,8 +359,7 @@ export const buildResolvedSitemapUrlsCached = defineCachedFunction(
 // Routes between Nitro's storage-backed cache (production) and direct execution. Chunks of the
 // same base sitemap share one cache entry so the source fetch + normalize + sort runs once per
 // `cacheMaxAgeSeconds` window. Edge-runtime safe: relies on Nitro's storage layer, no module
-// state. Dev and prerender skip the cache (prerender to avoid poisoning from early empty-source
-// reads; dev to keep iteration fast).
+// state. Dev and prerender skip the cache so updated sources remain visible.
 export async function getResolvedSitemapUrls(
   effectiveSitemap: SitemapDefinition,
   matchName: string,

--- a/src/runtime/server/sitemap/nitro.ts
+++ b/src/runtime/server/sitemap/nitro.ts
@@ -314,9 +314,8 @@ export async function createSitemap(event: H3Event, definition: SitemapDefinitio
   const shouldStream = !!runtimeConfig.experimentalStreaming && !import.meta.prerender
 
   // Choose between cached or direct generation.
-  // Skip caching during prerender: the crawl may run before `prerender:done` has written
-  // `global-sources.json`, so an early empty result would poison the cache and be returned
-  // on the follow-up render, shipping an empty sitemap.
+  // Skip caching during prerender so the final filesystem source handoff can replace
+  // the initial build-time sources after the crawl.
   // A serialized XML cache necessarily buffers the entire response. Streaming mode caches
   // the finalized render plan instead and serializes those resolved URLs on demand.
   const shouldCache = !import.meta.dev && !import.meta.prerender && typeof runtimeConfig.cacheMaxAgeSeconds === 'number' && runtimeConfig.cacheMaxAgeSeconds > 0

--- a/test/e2e/single/prerender-early-source.test.ts
+++ b/test/e2e/single/prerender-early-source.test.ts
@@ -1,0 +1,16 @@
+import { readFile } from 'node:fs/promises'
+import { buildNuxt, createResolver, loadNuxt } from '@nuxt/kit'
+import { describe, expect, it } from 'vitest'
+
+describe('prerender source handoff', () => {
+  it('makes configured URLs available before prerender:done', async () => {
+    const { resolve } = createResolver(import.meta.url)
+    const rootDir = resolve('../../fixtures/prerender-early-source')
+    const nuxt = await loadNuxt({ rootDir })
+
+    await buildNuxt(nuxt)
+
+    const earlySitemap = await readFile(resolve(rootDir, '.output/public/early-sitemap/index.html'), 'utf8')
+    expect(earlySitemap).toContain('<loc>https://example.com/configured</loc>')
+  }, 120000)
+})

--- a/test/fixtures/prerender-early-source/nuxt.config.ts
+++ b/test/fixtures/prerender-early-source/nuxt.config.ts
@@ -1,0 +1,19 @@
+import NuxtSitemap from '../../../src/module'
+
+export default defineNuxtConfig({
+  modules: [NuxtSitemap],
+  site: {
+    url: 'https://example.com',
+  },
+  nitro: {
+    prerender: {
+      routes: ['/early-sitemap'],
+    },
+  },
+  sitemap: {
+    credits: false,
+    excludeAppSources: true,
+    urls: ['/configured'],
+    zeroRuntime: true,
+  },
+})

--- a/test/fixtures/prerender-early-source/server/routes/early-sitemap.get.ts
+++ b/test/fixtures/prerender-early-source/server/routes/early-sitemap.get.ts
@@ -1,0 +1,3 @@
+import { defineEventHandler } from 'h3'
+
+export default defineEventHandler(event => event.$fetch('/sitemap.xml'))


### PR DESCRIPTION
### 🔗 Linked issue

Related to harlan-zw/nuxt-ai-ready#57

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Configured sources were unavailable when another prerendered route requested the sitemap before `prerender:done`. Seed the virtual source modules with build-time sources, then let the filesystem handoff replace them after the route crawl.

Adds a regression that requests `/sitemap.xml` during prerender and verifies `sitemap.urls` is present.