### PR TITLE
fix(utils): restore legacy sitemap parser exports

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,25 @@
 export type * from '../runtime/types'
+export {
+  isSitemapIndex,
+  parseSitemapIndex,
+  parseSitemapIndexStream,
+  parseSitemapStream,
+  parseSitemapXml,
+  parseSitemapXmlStream,
+} from './legacySitemap'
+export type {
+  SitemapIndexEntry,
+  SitemapIndexParseResult,
+  SitemapIndexStreamEvent,
+  SitemapKind,
+  SitemapParseResult,
+  SitemapStreamEvent,
+  SitemapStreamOptions,
+  SitemapWarning,
+  SitemapXmlChunk,
+  SitemapXmlInput,
+  SitemapXmlStreamEvent,
+} from './legacySitemap'
 export { parseHtmlExtractSitemapMeta } from './parseHtmlExtractSitemapMeta'
 export { createSitemapReader } from 'sitemapd'
 export type {

--- a/src/utils/legacySitemap.ts
+++ b/src/utils/legacySitemap.ts
@@ -1,0 +1,383 @@
+import type {
+  SitemapInput,
+  SitemapIssue,
+  SitemapUrlRecord,
+} from 'sitemapd/parse'
+import type {
+  Changefreq,
+  GoogleNewsEntry,
+  ImageEntry,
+  SitemapUrl,
+  SitemapUrlInput,
+  VideoEntry,
+} from '../runtime/types'
+import { parseSitemap } from 'sitemapd/parse'
+
+/** @deprecated Use `SitemapIssue` with `parseSitemap` or `collectSitemap`. */
+export interface SitemapWarning {
+  type: 'validation'
+  message: string
+  context?: {
+    url?: string
+    field?: string
+    value?: unknown
+  }
+}
+
+/** @deprecated Use the tagged `CollectSitemapResult` returned by `collectSitemap`. */
+export interface SitemapParseResult {
+  urls: SitemapUrlInput[]
+  warnings: SitemapWarning[]
+}
+
+/** @deprecated Use `SitemapReference`. */
+export interface SitemapIndexEntry {
+  loc: string
+  lastmod?: string
+}
+
+/** @deprecated Use the tagged `CollectSitemapResult` returned by `collectSitemap`. */
+export interface SitemapIndexParseResult {
+  entries: SitemapIndexEntry[]
+  warnings: SitemapWarning[]
+}
+
+/** @deprecated Use `SitemapInput`. */
+export type SitemapXmlChunk = string | Uint8Array
+/** @deprecated Use `SitemapInput`. */
+export type SitemapXmlInput = SitemapInput
+
+/** @deprecated Use `ParseSitemapOptions`. */
+export interface SitemapStreamOptions {
+  maxEntryBytes?: number
+  maxBufferBytes?: number
+}
+
+/** @deprecated Use `SitemapParseEvent`. */
+export type SitemapXmlStreamEvent
+  = { _tag: 'url', url: SitemapUrlInput }
+    | { _tag: 'warning', warning: SitemapWarning }
+
+/** @deprecated Use `SitemapParseEvent`. */
+export type SitemapIndexStreamEvent
+  = { _tag: 'sitemap', sitemap: SitemapIndexEntry }
+    | { _tag: 'warning', warning: SitemapWarning }
+
+/** @deprecated Use `SitemapDocumentKind`. */
+export type SitemapKind = 'urlset' | 'index'
+
+/** @deprecated Use `SitemapParseEvent`. */
+export type SitemapStreamEvent
+  = { _tag: 'kind', kind: SitemapKind }
+    | SitemapXmlStreamEvent
+    | SitemapIndexStreamEvent
+
+const CHANGE_FREQUENCIES = new Set<Changefreq>([
+  'always',
+  'hourly',
+  'daily',
+  'weekly',
+  'monthly',
+  'yearly',
+  'never',
+])
+
+function legacyWarning(issue: SitemapIssue, kind: SitemapKind): SitemapWarning | undefined {
+  if (issue.code === 'missing_loc') {
+    return {
+      type: 'validation',
+      message: kind === 'index'
+        ? 'Sitemap entry missing required loc element'
+        : 'URL entry missing required loc element',
+      ...(kind === 'urlset' ? { context: { url: 'undefined' } } : {}),
+    }
+  }
+  if (issue.code === 'invalid_loc' && kind === 'index') {
+    const url = String(issue.value)
+    if (URL.canParse(url))
+      return undefined
+    return {
+      type: 'validation',
+      message: 'Sitemap entry has invalid URL',
+      context: { url },
+    }
+  }
+  if (issue.severity !== 'warning' || issue.code === 'invalid_loc')
+    return undefined
+  return {
+    type: 'validation',
+    message: issue.message,
+    ...((issue.field || issue.value !== undefined)
+      ? {
+          context: {
+            ...(issue.field ? { field: issue.field } : {}),
+            ...(issue.value !== undefined ? { value: issue.value } : {}),
+          },
+        }
+      : {}),
+  }
+}
+
+function legacyImages(images: NonNullable<SitemapUrlRecord['extensions']>['images']): ImageEntry[] | undefined {
+  return images?.map(image => ({
+    loc: image.loc,
+    ...(image.caption ? { caption: image.caption } : {}),
+    ...(image.geoLocation ? { geo_location: image.geoLocation } : {}),
+    ...(image.title ? { title: image.title } : {}),
+    ...(image.license ? { license: image.license } : {}),
+  }))
+}
+
+function legacyUrl(entry: SitemapUrlRecord): { url: SitemapUrl, warnings: SitemapWarning[] } {
+  const warnings: SitemapWarning[] = []
+  const url: SitemapUrl = { loc: entry.loc }
+
+  if (entry.lastmod)
+    url.lastmod = entry.lastmod
+
+  if (entry.changefreq) {
+    if (CHANGE_FREQUENCIES.has(entry.changefreq as Changefreq)) {
+      url.changefreq = entry.changefreq as Changefreq
+    }
+    else {
+      warnings.push({
+        type: 'validation',
+        message: 'Invalid changefreq value',
+        context: { url: entry.loc, field: 'changefreq', value: entry.changefreq },
+      })
+    }
+  }
+
+  if (entry.priority !== undefined) {
+    const priority = Number.parseFloat(entry.priority)
+    if (Number.isNaN(priority)) {
+      warnings.push({
+        type: 'validation',
+        message: 'Invalid priority value',
+        context: { url: entry.loc, field: 'priority', value: entry.priority },
+      })
+    }
+    else {
+      if (priority < 0 || priority > 1) {
+        warnings.push({
+          type: 'validation',
+          message: 'Priority value should be between 0.0 and 1.0, clamping to valid range',
+          context: { url: entry.loc, field: 'priority', value: priority },
+        })
+      }
+      url.priority = Math.max(0, Math.min(1, priority)) as SitemapUrl['priority']
+    }
+  }
+
+  const extensions = entry.extensions
+  if (extensions?.alternatives) {
+    url.alternatives = extensions.alternatives.flatMap((alternative) => {
+      if ((!alternative.rel || alternative.rel === 'alternate') && alternative.hreflang)
+        return [{ hreflang: alternative.hreflang, href: alternative.href }]
+      warnings.push({
+        type: 'validation',
+        message: 'Alternative link missing required rel="alternate", hreflang, or href',
+        context: { url: entry.loc, field: 'link' },
+      })
+      return []
+    })
+  }
+  const images = legacyImages(extensions?.images)
+  if (images?.length)
+    url.images = images
+  if (extensions?.videos?.length)
+    url.videos = extensions.videos as unknown as VideoEntry[]
+  if (extensions?.news)
+    url.news = extensions.news as unknown as GoogleNewsEntry
+
+  return { url, warnings }
+}
+
+function positiveOption(value: number | undefined, name: string): number | undefined {
+  if (value === undefined)
+    return undefined
+  if (!Number.isSafeInteger(value) || value < 1)
+    throw new TypeError(`${name} must be a positive safe integer`)
+  return value
+}
+
+function parserFailure(
+  issue: SitemapIssue | undefined,
+  kind: SitemapKind | undefined,
+  options: SitemapStreamOptions,
+): Error {
+  if (issue?.code === 'empty')
+    return new Error('Empty XML input provided')
+  if (issue?.code === 'decoded_limit' && options.maxBufferBytes)
+    return new Error(`Sitemap XML buffer exceeds maxBufferBytes of ${options.maxBufferBytes}`)
+  const entryLimit = issue?.message.match(/^Sitemap entry exceeds (\d+) bytes$/)
+  if (entryLimit)
+    return new Error(`Sitemap entry exceeds maxEntryBytes of ${entryLimit[1]}`)
+  if (issue?.code === 'unsupported' || issue?.code === 'html') {
+    return new Error(
+      kind === 'index'
+        ? 'XML does not contain a valid sitemapindex element'
+        : kind === 'urlset'
+          ? 'XML does not contain a valid urlset element'
+          : 'XML does not contain a valid sitemap element',
+    )
+  }
+  return new Error(`Failed to parse XML: ${issue?.message || 'Malformed sitemap'}`)
+}
+
+async function* parseSitemapStreamInternal(
+  input: SitemapXmlInput,
+  options: SitemapStreamOptions = {},
+  expectedKind?: SitemapKind,
+): AsyncGenerator<SitemapStreamEvent> {
+  const maxEntryBytes = positiveOption(options.maxEntryBytes, 'maxEntryBytes')
+  const maxBufferBytes = positiveOption(options.maxBufferBytes, 'maxBufferBytes')
+  let kind: SitemapKind | undefined
+  let lastIssue: SitemapIssue | undefined
+  let invalidUrlEntries = 0
+  let validUrls = 0
+
+  for await (const event of parseSitemap(input, {
+    ...(maxEntryBytes ? { maxEntryBytes } : {}),
+    ...(maxBufferBytes ? { maxDecodedBytes: maxBufferBytes } : {}),
+  })) {
+    if (event._tag === 'document') {
+      if (event.format !== 'xml') {
+        throw new Error(
+          expectedKind === 'index'
+            ? 'XML does not contain a valid sitemapindex element'
+            : expectedKind === 'urlset'
+              ? 'XML does not contain a valid urlset element'
+              : 'XML does not contain a valid sitemap element',
+        )
+      }
+      kind = event.kind
+      yield { _tag: 'kind', kind }
+    }
+    else if (event._tag === 'issue') {
+      lastIssue = event.issue
+      if (!kind)
+        continue
+      if (event.issue.code === 'missing_loc' && kind === 'urlset')
+        invalidUrlEntries++
+      const warning = legacyWarning(event.issue, kind)
+      if (warning)
+        yield { _tag: 'warning', warning }
+    }
+    else if (event._tag === 'url') {
+      validUrls++
+      const mapped = legacyUrl(event.entry)
+      for (const warning of mapped.warnings)
+        yield { _tag: 'warning', warning }
+      yield { _tag: 'url', url: mapped.url }
+    }
+    else if (event._tag === 'sitemap') {
+      if (!URL.canParse(event.entry.loc))
+        continue
+      yield { _tag: 'sitemap', sitemap: event.entry }
+    }
+    else if (event.completeness._tag !== 'complete') {
+      throw parserFailure(lastIssue, kind || expectedKind, options)
+    }
+  }
+
+  if (kind === 'urlset' && invalidUrlEntries > 0 && validUrls === 0) {
+    yield {
+      _tag: 'warning',
+      warning: {
+        type: 'validation',
+        message: 'No valid URLs found in sitemap after validation',
+      },
+    }
+  }
+}
+
+/**
+ * @deprecated Use `parseSitemap` from `@nuxtjs/sitemap/utils`. Canonical
+ * streams emit `document`, `url`, `sitemap`, `issue`, and terminal `end`
+ * events. URL and sitemap payloads use `entry`.
+ */
+export async function* parseSitemapStream(
+  input: SitemapXmlInput,
+  options: SitemapStreamOptions = {},
+): AsyncGenerator<SitemapStreamEvent> {
+  yield* parseSitemapStreamInternal(input, options)
+}
+
+/**
+ * @deprecated Use `parseSitemap` from `@nuxtjs/sitemap/utils` and handle
+ * events whose document kind is `urlset`.
+ */
+export async function* parseSitemapXmlStream(
+  input: SitemapXmlInput,
+  options: SitemapStreamOptions = {},
+): AsyncGenerator<SitemapXmlStreamEvent> {
+  for await (const event of parseSitemapStreamInternal(input, options, 'urlset')) {
+    if (event._tag === 'kind') {
+      if (event.kind !== 'urlset')
+        throw new Error('XML does not contain a valid urlset element')
+      continue
+    }
+    if (event._tag !== 'sitemap')
+      yield event
+  }
+}
+
+/**
+ * @deprecated Use `parseSitemap` from `@nuxtjs/sitemap/utils` and handle
+ * events whose document kind is `index`.
+ */
+export async function* parseSitemapIndexStream(
+  input: SitemapXmlInput,
+  options: SitemapStreamOptions = {},
+): AsyncGenerator<SitemapIndexStreamEvent> {
+  for await (const event of parseSitemapStreamInternal(input, options, 'index')) {
+    if (event._tag === 'kind') {
+      if (event.kind !== 'index')
+        throw new Error('XML does not contain a valid sitemapindex element')
+      continue
+    }
+    if (event._tag !== 'url')
+      yield event
+  }
+}
+
+/**
+ * @deprecated Use `collectSitemap` from `@nuxtjs/sitemap/utils` and handle
+ * its tagged result.
+ */
+export async function parseSitemapXml(xml: string): Promise<SitemapParseResult> {
+  const urls: SitemapUrlInput[] = []
+  const warnings: SitemapWarning[] = []
+  for await (const event of parseSitemapXmlStream(xml)) {
+    if (event._tag === 'url')
+      urls.push(event.url)
+    else
+      warnings.push(event.warning)
+  }
+  return { urls, warnings }
+}
+
+/**
+ * @deprecated Use `collectSitemap` from `@nuxtjs/sitemap/utils` and handle
+ * an `index` document result.
+ */
+export async function parseSitemapIndex(xml: string): Promise<SitemapIndexParseResult> {
+  const entries: SitemapIndexEntry[] = []
+  const warnings: SitemapWarning[] = []
+  for await (const event of parseSitemapIndexStream(xml)) {
+    if (event._tag === 'sitemap')
+      entries.push(event.sitemap)
+    else
+      warnings.push(event.warning)
+  }
+  return { entries, warnings }
+}
+
+/**
+ * @deprecated Use `collectSitemap` from `@nuxtjs/sitemap/utils` and inspect
+ * the tagged document result.
+ */
+export function isSitemapIndex(xml: string): boolean {
+  return xml.includes('<sitemapindex') || xml.includes('sitemapindex>')
+}

--- a/test/types/stream-utils.test-d.ts
+++ b/test/types/stream-utils.test-d.ts
@@ -1,8 +1,11 @@
 import type {
   FetchDocumentLoaderOptions,
   SitemapDocumentLoader,
+  SitemapIndexStreamEvent,
   SitemapParseEvent,
   SitemapReader,
+  SitemapStreamEvent,
+  SitemapXmlStreamEvent,
 } from '../../src/utils'
 import { describe, expectTypeOf, it } from 'vitest'
 import {
@@ -11,6 +14,11 @@ import {
   createSitemapReader,
   parseHtmlExtractSitemapMeta,
   parseSitemap,
+  parseSitemapIndex,
+  parseSitemapIndexStream,
+  parseSitemapStream,
+  parseSitemapXml,
+  parseSitemapXmlStream,
 } from '../../src/utils'
 
 describe('stream parsing utilities', () => {
@@ -21,8 +29,13 @@ describe('stream parsing utilities', () => {
 
   it('preserves the existing utility exports', () => {
     expectTypeOf(collectSitemap).toBeFunction()
+    expectTypeOf(parseSitemapIndex).toBeFunction()
+    expectTypeOf(parseSitemapIndexStream('')).toMatchTypeOf<AsyncIterable<SitemapIndexStreamEvent>>()
     expectTypeOf(parseHtmlExtractSitemapMeta).toBeFunction()
     expectTypeOf(parseSitemap).toBeFunction()
+    expectTypeOf(parseSitemapStream('')).toMatchTypeOf<AsyncIterable<SitemapStreamEvent>>()
+    expectTypeOf(parseSitemapXml).toBeFunction()
+    expectTypeOf(parseSitemapXmlStream('')).toMatchTypeOf<AsyncIterable<SitemapXmlStreamEvent>>()
   })
 
   it('re-exports the reader and Fetch adapter', () => {

--- a/test/unit/legacy-parser-compat.test.ts
+++ b/test/unit/legacy-parser-compat.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isSitemapIndex,
+  parseSitemapIndex,
+  parseSitemapIndexStream,
+  parseSitemapStream,
+  parseSitemapXml,
+  parseSitemapXmlStream,
+} from '../../src/utils'
+
+async function collect<T>(source: AsyncIterable<T>): Promise<T[]> {
+  const values: T[] = []
+  for await (const value of source)
+    values.push(value)
+  return values
+}
+
+describe('legacy parser compatibility', () => {
+  it('restores the @nuxtjs/sitemap/utils parser exports', async () => {
+    const xml = '<urlset><url><loc>https://example.com/</loc><priority>0.7</priority></url></urlset>'
+
+    await expect(parseSitemapXml(xml)).resolves.toEqual({
+      urls: [{ loc: 'https://example.com/', priority: 0.7 }],
+      warnings: [],
+    })
+    await expect(collect(parseSitemapXmlStream(xml))).resolves.toEqual([
+      { _tag: 'url', url: { loc: 'https://example.com/', priority: 0.7 } },
+    ])
+    await expect(collect(parseSitemapStream(xml))).resolves.toEqual([
+      { _tag: 'kind', kind: 'urlset' },
+      { _tag: 'url', url: { loc: 'https://example.com/', priority: 0.7 } },
+    ])
+  })
+
+  it('restores sitemap index parsing', async () => {
+    const xml = '<sitemapindex><sitemap><loc>https://example.com/a.xml</loc></sitemap></sitemapindex>'
+
+    expect(isSitemapIndex(xml)).toBe(true)
+    await expect(parseSitemapIndex(xml)).resolves.toEqual({
+      entries: [{ loc: 'https://example.com/a.xml' }],
+      warnings: [],
+    })
+    await expect(collect(parseSitemapIndexStream(xml))).resolves.toEqual([
+      { _tag: 'sitemap', sitemap: { loc: 'https://example.com/a.xml' } },
+    ])
+  })
+
+  it('preserves parser specific errors', async () => {
+    await expect(parseSitemapXml('<other />')).rejects.toThrow('XML does not contain a valid urlset element')
+    await expect(parseSitemapIndex('<other />')).rejects.toThrow('XML does not contain a valid sitemapindex element')
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

Resolves harlan-zw/nuxt-ai-ready#59

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`@nuxtjs/sitemap` 8.3.1 removed parser exports used by `nuxt-ai-ready`, causing Nitro builds to fail. Restore deprecated adapters backed by `sitemapd`, with migration hints for `parseSitemap` and `collectSitemap`.