### PR TITLE
fix: use shared Nitro fetch alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "release:sitemapd": "pnpm --filter sitemapd release",
     "test": "pnpm --filter sitemapd test && vitest run && pnpm run test:attw && pnpm run test:nuxt5",
     "test:unit": "vitest --project=unit",
-    "test:nuxt5": "pnpm pack --out test/fixtures/nuxt5/module.tgz && pnpm --dir test/fixtures/nuxt5 install --frozen-lockfile && pnpm --dir test/fixtures/nuxt5 test",
+    "test:nuxt5": "pnpm pack --out test/fixtures/nuxt5/module.tgz && pnpm install --dir test/fixtures/nuxt5 --no-frozen-lockfile --update-checksums && pnpm --dir test/fixtures/nuxt5 test",
     "test:attw": "attw --pack && pnpm --filter sitemapd test:attw",
     "typecheck": "pnpm --filter sitemapd typecheck && nuxt typecheck",
     "prepare": "skilld prepare || true"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,8 +79,8 @@ catalogs:
       specifier: ^5.3.6
       version: 5.3.7
     nuxtseo-shared:
-      specifier: ^5.3.8
-      version: 5.3.8
+      specifier: ^5.3.9
+      version: 5.3.9
     ofetch:
       specifier: ^1.5.1
       version: 1.5.1
@@ -146,7 +146,7 @@ importers:
         version: 4.1.4(048941b7b1c82fe9245240620da99b6d)
       nuxtseo-shared:
         specifier: 'catalog:'
-        version: 5.3.8(f667c0f93f2e0019ae3ff86dede7b3ec)
+        version: 5.3.9(f667c0f93f2e0019ae3ff86dede7b3ec)
       ofetch:
         specifier: 'catalog:'
         version: 1.5.1
@@ -5844,8 +5844,8 @@ packages:
       zod:
         optional: true
 
-  nuxtseo-shared@5.3.8:
-    resolution: {integrity: sha512-2NOB0I5ikvgChNF5s6OXsxOvNSmluRxaTbS0T1s5EC7X/nzAQXM+OaGYL2D8JffH6HutTayJftJEiFeE+WDbcg==}
+  nuxtseo-shared@5.3.9:
+    resolution: {integrity: sha512-TFp6klJ+K1QJGjfWSP6812ELehdsE0CKPTbbpFT5hV18+GNT76RavnimgJ4xYJlaU8SIbPq9di40JBGORN6wRA==}
     peerDependencies:
       '@nuxt/schema': ^3.16.0 || ^4.0.0 || ^5.0.0
       nuxt: ^3.16.0 || ^4.0.0 || ^5.0.0
@@ -10191,7 +10191,7 @@ snapshots:
       defu: 6.1.7
       h3: 1.15.11
       nuxt-site-config: 4.1.4(048941b7b1c82fe9245240620da99b6d)
-      nuxtseo-shared: 5.3.8(f667c0f93f2e0019ae3ff86dede7b3ec)
+      nuxtseo-shared: 5.3.9(f667c0f93f2e0019ae3ff86dede7b3ec)
       pathe: 2.0.3
       pkg-types: 2.3.1
       ufo: 1.6.4
@@ -14847,7 +14847,7 @@ snapshots:
       defu: 6.1.7
       h3: 1.15.11
       nuxt-site-config-kit: 4.1.4(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.1)(rollup@4.62.4)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)))(vue@3.5.40(typescript@6.0.3))
-      nuxtseo-shared: 5.3.8(f667c0f93f2e0019ae3ff86dede7b3ec)
+      nuxtseo-shared: 5.3.9(f667c0f93f2e0019ae3ff86dede7b3ec)
       pathe: 2.0.3
       pkg-types: 2.3.1
       site-config-stack: 4.1.4(vue@3.5.40(typescript@6.0.3))
@@ -15271,7 +15271,7 @@ snapshots:
       - unplugin
       - vite
 
-  nuxtseo-shared@5.3.8(f667c0f93f2e0019ae3ff86dede7b3ec):
+  nuxtseo-shared@5.3.9(f667c0f93f2e0019ae3ff86dede7b3ec):
     dependencies:
       '@clack/prompts': 1.7.0
       '@nuxt/devtools-kit': 4.0.0-alpha.7(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.1)(rollup@4.62.4)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -68,7 +68,7 @@ catalog:
   nuxt-i18n-micro: ^3.26.0
   nuxt-site-config: ^4.1.4
   nuxtseo-layer-devtools: ^5.3.6
-  nuxtseo-shared: ^5.3.8
+  nuxtseo-shared: ^5.3.9
   ofetch: ^1.5.1
   pathe: ^2.0.3
   pkg-types: ^2.3.1

--- a/src/module.ts
+++ b/src/module.ts
@@ -142,7 +142,6 @@ export default defineNuxtModule<ModuleOptions>({
     config.exclude!.push(`${withTrailingSlash(nuxt.options.app.buildAssetsDir)}**`)
     nuxt.options.alias['#sitemap'] = resolve('./runtime')
     nuxt.options.nitro.alias = nuxt.options.nitro.alias || {}
-    nuxt.options.nitro.alias.ofetch ||= resolveModule('ofetch', { url: new URL(import.meta.url) })
     nuxt.options.nitro.alias['#sitemap'] = resolve('./runtime')
     nuxt.options.experimental.extraPageMetaExtractionKeys = nuxt.options.experimental.extraPageMetaExtractionKeys || []
     nuxt.options.experimental.extraPageMetaExtractionKeys.push('sitemap')

--- a/test/fixtures/nuxt5/pnpm-lock.yaml
+++ b/test/fixtures/nuxt5/pnpm-lock.yaml
@@ -355,7 +355,7 @@ packages:
         optional: true
 
   '@nuxtjs/sitemap@file:module.tgz':
-    resolution: {integrity: sha512-xUyZG8UpuYipeCXkbQfafvfRiUpDdWaWrqBUbnRxaBKCgmL0i8MKQFq8TV9wVtSGYa9WeoBmCA+U1QjS7Yclww==, tarball: file:module.tgz}
+    resolution: {integrity: sha512-N/k5+tRtV90P2lQ+15Wl2n+HHWtNggNeH67X6EQHSQKv8qbV3IYvgh6EVHWmzc6JkBg2XkF1ZGJC3aOB69TE9Q==, tarball: file:module.tgz}
     version: 8.3.2
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -1313,8 +1313,8 @@ packages:
       zod:
         optional: true
 
-  nuxtseo-shared@5.3.8:
-    resolution: {integrity: sha512-2NOB0I5ikvgChNF5s6OXsxOvNSmluRxaTbS0T1s5EC7X/nzAQXM+OaGYL2D8JffH6HutTayJftJEiFeE+WDbcg==}
+  nuxtseo-shared@5.3.9:
+    resolution: {integrity: sha512-TFp6klJ+K1QJGjfWSP6812ELehdsE0CKPTbbpFT5hV18+GNT76RavnimgJ4xYJlaU8SIbPq9di40JBGORN6wRA==}
     peerDependencies:
       '@nuxt/schema': ^3.16.0 || ^4.0.0 || ^5.0.0
       nuxt: ^3.16.0 || ^4.0.0 || ^5.0.0
@@ -2591,7 +2591,7 @@ snapshots:
       consola: 3.4.2
       defu: 6.1.7
       nuxt-site-config: 4.1.4(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
-      nuxtseo-shared: 5.3.8(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(nuxt-site-config@4.1.4(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
+      nuxtseo-shared: 5.3.9(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(nuxt-site-config@4.1.4(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
       ofetch: 1.5.1
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -3628,7 +3628,7 @@ snapshots:
       - unplugin
       - vite
 
-  nuxtseo-shared@5.3.8(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(nuxt-site-config@4.1.4(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3):
+  nuxtseo-shared@5.3.9(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(nuxt-site-config@4.1.4(@nuxt/schema@4.5.1)(magic-string@1.1.0)(magicast@0.5.4)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))(zod@4.4.3):
     dependencies:
       '@clack/prompts': 1.7.0
       '@nuxt/devtools-kit': 4.0.0-alpha.7(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)

--- a/test/fixtures/nuxt5/pnpm-workspace.yaml
+++ b/test/fixtures/nuxt5/pnpm-workspace.yaml
@@ -9,5 +9,6 @@ minimumReleaseAgeExclude:
   - site-config-stack@4.1.4
   - sitemapd@0.2.1
   - nuxtseo-shared@5.3.8
+  - nuxtseo-shared@5.3.9
   # nuxt-site-config@4.1.4 still resolves this transitive version.
   - nuxtseo-shared@5.3.7


### PR DESCRIPTION
## Summary

Use `nuxtseo-shared@5.3.9` as the single owner of Nitro 3 fetch compatibility.

This removes the module-level global `ofetch` alias while keeping the direct dependency used by sitemap runtime code. The packed Nuxt 5 fixture now refreshes local package checksums before install.

## Verification

- `pnpm dev:prepare`
- packed Nuxt 5 fixture
- ESLint on changed source and fixture files
