### PR TITLE
feat(sitemapd): add resumable traversal frontiers

### DIFF
--- a/packages/sitemapd/README.md
+++ b/packages/sitemapd/README.md
@@ -63,3 +63,27 @@ and returns a partial result with the `cancelled` reason. A visitor rejection or
 an unexpected loader or authorizer exception aborts active reads and rejects
 `walk()` with the original error. Tagged read failures remain values in the
 walk result.
+
+Partial results expose a breadth-first `frontier`. Pass that frontier into a
+later `walk()` together with the previously committed document URLs to continue
+without resetting depth or reading a document twice:
+
+```ts
+const first = await reader.walk(roots, {
+  maxDocuments: 40,
+  retention: 'none',
+})
+
+if (first._tag === 'partial' && first.frontier.length > 0) {
+  const resumed = await reader.walk(first.frontier, {
+    seenDocuments: committedDocumentUrls,
+    maxDocuments: 40,
+    retention: 'none',
+  })
+}
+```
+
+The frontier contains only scheduler work that remained eligible. Children
+blocked by `maxDepth` are excluded, so resuming cannot bypass the original depth
+limit. Read failures remain tagged values; the host decides whether to add a
+failed entry to a later frontier.

--- a/packages/sitemapd/src/reader.ts
+++ b/packages/sitemapd/src/reader.ts
@@ -1,13 +1,14 @@
 import type { SitemapReference, SitemapUrlRecord } from './parse'
 import type {
   SitemapLoadRequest,
-  SitemapLoadSource,
   SitemapReader,
   SitemapReaderOptions,
   SitemapReadOptions,
   SitemapReadResult,
   SitemapWalkDocument,
+  SitemapWalkEntry,
   SitemapWalkFailure,
+  SitemapWalkInput,
   SitemapWalkNonRetainedResult,
   SitemapWalkOptions,
   SitemapWalkPartialReason,
@@ -40,6 +41,27 @@ function parseConcurrency(value: number | undefined): number {
 
 function unique<T>(values: T[]): T[] {
   return [...new Set(values)]
+}
+
+function parseWalkInput(input: SitemapWalkInput): SitemapWalkEntry[] {
+  if (typeof input === 'string') {
+    return [{ url: input, depth: 0, source: 'root' }]
+  }
+  if (input.every((entry): entry is string => typeof entry === 'string')) {
+    return input.map(url => ({ url, depth: 0, source: 'root' }))
+  }
+  return input.map((entry) => {
+    if (entry.source === 'root') {
+      if (entry.depth !== 0 || entry.parentUrl !== undefined)
+        throw new TypeError('A root walk entry must have depth 0 and no parentUrl')
+      return { url: entry.url, depth: 0, source: 'root' }
+    }
+    if (!Number.isSafeInteger(entry.depth) || entry.depth < 1)
+      throw new RangeError('An index child walk entry must have a positive safe depth')
+    if (!entry.parentUrl)
+      throw new TypeError('An index child walk entry requires parentUrl')
+    return { ...entry }
+  })
 }
 
 export function createSitemapReader(options: SitemapReaderOptions): SitemapReader {
@@ -151,19 +173,19 @@ export function createSitemapReader(options: SitemapReaderOptions): SitemapReade
   }
 
   function walk(
-    roots: string | readonly string[],
+    input: SitemapWalkInput,
     walkOptions: SitemapWalkOptions & { retention: 'none' },
   ): Promise<SitemapWalkNonRetainedResult>
   function walk(
-    roots: string | readonly string[],
+    input: SitemapWalkInput,
     walkOptions?: SitemapWalkOptions & { retention?: 'all' },
   ): Promise<SitemapWalkRetainedResult>
   function walk(
-    roots: string | readonly string[],
+    input: SitemapWalkInput,
     walkOptions?: SitemapWalkOptions,
   ): Promise<SitemapWalkResult>
   async function walk(
-    roots: string | readonly string[],
+    input: SitemapWalkInput,
     walkOptions: SitemapWalkOptions = {},
   ): Promise<SitemapWalkResult> {
     const maxDepth = parseLimit(
@@ -183,12 +205,7 @@ export function createSitemapReader(options: SitemapReaderOptions): SitemapReade
     )
     const concurrency = parseConcurrency(walkOptions.concurrency)
     const retainEntries = walkOptions.retention !== 'none'
-    interface QueueItem {
-      url: string
-      depth: number
-      source: SitemapLoadSource
-      parentUrl?: string
-    }
+    type QueueItem = SitemapWalkEntry
     type Settlement
       = | {
         _tag: 'result'
@@ -202,12 +219,8 @@ export function createSitemapReader(options: SitemapReaderOptions): SitemapReade
         item: QueueItem
         error: unknown
       }
-    const queue: QueueItem[] = (typeof roots === 'string' ? [roots] : [...roots]).map(url => ({
-      url,
-      depth: 0,
-      source: 'root',
-    }))
-    const seenDocuments = new Set<string>()
+    const queue: QueueItem[] = parseWalkInput(input)
+    const seenDocuments = new Set(walkOptions.seenDocuments ?? [])
     const seenUrls = retainEntries ? new Set<string>() : null
     const entries: SitemapUrlRecord[] = []
     const references: SitemapReference[] = []
@@ -215,6 +228,8 @@ export function createSitemapReader(options: SitemapReaderOptions): SitemapReade
     const reasons: SitemapWalkPartialReason[] = []
     const active = new Map<number, Promise<Settlement>>()
     const settled = new Map<number, Settlement>()
+    const scheduled = new Map<number, QueueItem>()
+    const interrupted: QueueItem[] = []
     const controller = new AbortController()
     const callerSignal = walkOptions.signal
     const abortFromCaller = () => {
@@ -241,13 +256,24 @@ export function createSitemapReader(options: SitemapReaderOptions): SitemapReade
     const hasQueuedDocument = (): boolean =>
       queue.some(item => !seenDocuments.has(item.url))
 
-    const stopAndDrain = async (reason: unknown): Promise<void> => {
+    const stopAndDrain = async (
+      reason: unknown,
+      preserveFrontier: boolean = false,
+    ): Promise<void> => {
       schedulingStopped = true
       if (!controller.signal.aborted)
         controller.abort(reason)
+      if (preserveFrontier) {
+        interrupted.push(
+          ...[...scheduled.entries()]
+            .sort(([left], [right]) => left - right)
+            .map(([, item]) => item),
+        )
+      }
       const pending = [...active.values()]
       active.clear()
       settled.clear()
+      scheduled.clear()
       await Promise.all(pending)
     }
 
@@ -268,6 +294,7 @@ export function createSitemapReader(options: SitemapReaderOptions): SitemapReade
         if (!next)
           return
         if (documentsAttempted >= maxDocuments) {
+          queue.unshift(next)
           reasons.push('document_limit')
           schedulingStopped = true
           return
@@ -296,6 +323,7 @@ export function createSitemapReader(options: SitemapReaderOptions): SitemapReade
           }),
         )
         active.set(sequence, promise)
+        scheduled.set(sequence, next)
       }
     }
 
@@ -333,6 +361,7 @@ export function createSitemapReader(options: SitemapReaderOptions): SitemapReade
           await stopAndDrain(
             callerSignal.reason
             ?? new DOMException('Sitemap traversal was cancelled', 'AbortError'),
+            true,
           )
           break
         }
@@ -349,6 +378,7 @@ export function createSitemapReader(options: SitemapReaderOptions): SitemapReade
         }
 
         settled.delete(nextCommit)
+        scheduled.delete(nextCommit)
         nextCommit++
         if (next._tag === 'thrown') {
           await stopAndDrain(next.error)
@@ -357,7 +387,7 @@ export function createSitemapReader(options: SitemapReaderOptions): SitemapReade
 
         const { item, result } = next
         if (result._tag !== 'ok') {
-          failures.push({ url: item.url, depth: item.depth, result })
+          failures.push({ ...item, result })
           reasons.push('read_failure')
           continue
         }
@@ -393,6 +423,7 @@ export function createSitemapReader(options: SitemapReaderOptions): SitemapReade
           reasons.push('url_limit')
           await stopAndDrain(
             new DOMException('Sitemap traversal reached its URL limit', 'AbortError'),
+            true,
           )
           break
         }
@@ -414,6 +445,7 @@ export function createSitemapReader(options: SitemapReaderOptions): SitemapReade
           reasons.push('url_limit')
           await stopAndDrain(
             new DOMException('Sitemap traversal reached its URL limit', 'AbortError'),
+            true,
           )
           break
         }
@@ -441,6 +473,23 @@ export function createSitemapReader(options: SitemapReaderOptions): SitemapReade
       documentsAttempted,
       documentsRead,
       failures,
+      frontier: (() => {
+        const urls = new Set<string>()
+        const result: SitemapWalkEntry[] = []
+        for (const entry of interrupted) {
+          if (urls.has(entry.url))
+            continue
+          urls.add(entry.url)
+          result.push(entry)
+        }
+        for (const entry of queue) {
+          if (seenDocuments.has(entry.url) || urls.has(entry.url))
+            continue
+          urls.add(entry.url)
+          result.push(entry)
+        }
+        return result
+      })(),
     } as const
     const partialReasons = unique(reasons)
     return partialReasons.length > 0

--- a/packages/sitemapd/src/types.ts
+++ b/packages/sitemapd/src/types.ts
@@ -89,8 +89,29 @@ export interface SitemapWalkOptions extends SitemapReadOptions {
   maxUrls?: number
   concurrency?: number
   retention?: 'all' | 'none'
+  /** Documents committed by an earlier bounded round. */
+  seenDocuments?: readonly string[]
   onDocument?: SitemapWalkDocumentVisitor
 }
+
+export type SitemapWalkEntry
+  = | {
+    url: string
+    depth: 0
+    source: 'root'
+    parentUrl?: never
+  }
+  | {
+    url: string
+    depth: number
+    source: 'index_child'
+    parentUrl: string
+  }
+
+export type SitemapWalkInput
+  = | string
+    | readonly string[]
+    | readonly SitemapWalkEntry[]
 
 export interface SitemapWalkDocument {
   requestedUrl: string
@@ -106,9 +127,7 @@ export type SitemapWalkDocumentVisitor = (
   document: SitemapWalkDocument,
 ) => void | Promise<void>
 
-export interface SitemapWalkFailure {
-  url: string
-  depth: number
+export type SitemapWalkFailure = SitemapWalkEntry & {
   result: Exclude<SitemapReadResult, { _tag: 'ok' }>
 }
 
@@ -126,6 +145,8 @@ interface SitemapWalkBaseData {
   documentsAttempted: number
   documentsRead: number
   failures: SitemapWalkFailure[]
+  /** Breadth-first work not committed before this bounded round stopped. */
+  frontier: SitemapWalkEntry[]
 }
 
 type SitemapWalkStatus
@@ -156,15 +177,15 @@ export interface SitemapReader {
   read: (url: string, options?: SitemapReadOptions) => Promise<SitemapReadResult>
   walk: {
     (
-      roots: string | readonly string[],
+      input: SitemapWalkInput,
       options: SitemapWalkOptions & { retention: 'none' },
     ): Promise<SitemapWalkNonRetainedResult>
     (
-      roots: string | readonly string[],
+      input: SitemapWalkInput,
       options?: SitemapWalkOptions & { retention?: 'all' },
     ): Promise<SitemapWalkRetainedResult>
     (
-      roots: string | readonly string[],
+      input: SitemapWalkInput,
       options?: SitemapWalkOptions,
     ): Promise<SitemapWalkResult>
   }

--- a/packages/sitemapd/test/reader.test.ts
+++ b/packages/sitemapd/test/reader.test.ts
@@ -289,7 +289,127 @@ describe('sitemap reader', () => {
       reasons: ['document_limit'],
       documentsAttempted: 2,
       documentsRead: 2,
+      frontier: [{
+        url: 'https://example.com/c.xml',
+        depth: 0,
+        source: 'root',
+      }],
     })
+  })
+
+  it('preserves depth when a frontier resumes', async () => {
+    const loaded: string[] = []
+    const documents = new Map([
+      [
+        'https://example.com/root.xml',
+        '<sitemapindex><sitemap><loc>https://example.com/level-1.xml</loc></sitemap></sitemapindex>',
+      ],
+      [
+        'https://example.com/level-1.xml',
+        '<sitemapindex><sitemap><loc>https://example.com/level-2.xml</loc></sitemap></sitemapindex>',
+      ],
+      ['https://example.com/level-2.xml', '<urlset></urlset>'],
+    ])
+    const reader = createSitemapReader({
+      loadDocument: async ({ url }) => {
+        loaded.push(url)
+        return {
+          _tag: 'body',
+          url,
+          body: encoder.encode(documents.get(url) ?? '<urlset></urlset>'),
+        }
+      },
+      authorizeTarget: async () => ({ _tag: 'allow' }),
+    })
+
+    const first = await reader.walk('https://example.com/root.xml', {
+      maxDepth: 1,
+      maxDocuments: 1,
+      retention: 'none',
+    })
+    expect(first).toMatchObject({
+      _tag: 'partial',
+      reasons: ['document_limit'],
+      frontier: [{
+        url: 'https://example.com/level-1.xml',
+        depth: 1,
+        source: 'index_child',
+        parentUrl: 'https://example.com/root.xml',
+      }],
+    })
+    if (first._tag !== 'partial')
+      throw new Error('Expected a resumable partial walk')
+
+    const second = await reader.walk(first.frontier, {
+      maxDepth: 1,
+      seenDocuments: ['https://example.com/root.xml'],
+      retention: 'none',
+    })
+    expect(second).toMatchObject({
+      _tag: 'partial',
+      reasons: ['depth_limit'],
+      documentsRead: 1,
+      frontier: [],
+    })
+    expect(loaded).toEqual([
+      'https://example.com/root.xml',
+      'https://example.com/level-1.xml',
+    ])
+  })
+
+  it('does not re-read a document seen before resuming', async () => {
+    const loaded: string[] = []
+    const documents = new Map([
+      [
+        'https://example.com/root.xml',
+        '<sitemapindex><sitemap><loc>https://example.com/shared.xml</loc></sitemap><sitemap><loc>https://example.com/branch.xml</loc></sitemap></sitemapindex>',
+      ],
+      [
+        'https://example.com/branch.xml',
+        '<sitemapindex><sitemap><loc>https://example.com/shared.xml</loc></sitemap></sitemapindex>',
+      ],
+      ['https://example.com/shared.xml', '<urlset></urlset>'],
+    ])
+    const reader = createSitemapReader({
+      loadDocument: async ({ url }) => {
+        loaded.push(url)
+        return {
+          _tag: 'body',
+          url,
+          body: encoder.encode(documents.get(url) ?? '<urlset></urlset>'),
+        }
+      },
+      authorizeTarget: async () => ({ _tag: 'allow' }),
+    })
+
+    const first = await reader.walk('https://example.com/root.xml', {
+      maxDocuments: 2,
+      retention: 'none',
+    })
+    expect(first).toMatchObject({
+      _tag: 'partial',
+      frontier: [{ url: 'https://example.com/branch.xml' }],
+    })
+    if (first._tag !== 'partial')
+      throw new Error('Expected a resumable partial walk')
+
+    const second = await reader.walk(first.frontier, {
+      seenDocuments: [
+        'https://example.com/root.xml',
+        'https://example.com/shared.xml',
+      ],
+      retention: 'none',
+    })
+    expect(second).toMatchObject({
+      _tag: 'complete',
+      documentsAttempted: 1,
+      documentsRead: 1,
+    })
+    expect(loaded).toEqual([
+      'https://example.com/root.xml',
+      'https://example.com/shared.xml',
+      'https://example.com/branch.xml',
+    ])
   })
 
   it('does not visit or retain a document that exceeds the aggregate URL budget', async () => {
@@ -410,6 +530,10 @@ describe('sitemap reader', () => {
       documentsAttempted: 2,
       documentsRead: 0,
       failures: [],
+      frontier: [
+        { url: 'https://example.com/a.xml', depth: 0, source: 'root' },
+        { url: 'https://example.com/b.xml', depth: 0, source: 'root' },
+      ],
     })
   })
 


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue.

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Bounded sitemap walks now return `frontier` entries with depth, source, and parent metadata. A later walk accepts that frontier plus `seenDocuments`, preserving depth limits and document deduplication across host-managed rounds.