### PR TITLE
fix(devtools): avoid `__dirname` in layer config

### DIFF
--- a/devtools/nuxt.config.ts
+++ b/devtools/nuxt.config.ts
@@ -1,7 +1,10 @@
+import { fileURLToPath } from 'node:url'
 import { resolve } from 'pathe'
+
+const currentDir = fileURLToPath(new URL('.', import.meta.url))
 
 // Nuxt SEO devtools panel, shipped as a layer (Model C). Components flat-registered
 // so intra-panel references resolve by name.
 export default defineNuxtConfig({
-  components: [{ path: resolve(__dirname, './components'), pathPrefix: false }],
+  components: [{ path: resolve(currentDir, './components'), pathPrefix: false }],
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

cjs globals have been polyfilled by jiti for a while but these aren't guaranteed to exist in the future