### PR TITLE
chore: adopt shared eslint base config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,42 +4,20 @@ import harlanzw from 'eslint-plugin-harlanzw'
 export default antfu(
   {
     type: 'lib',
-    ignores: [
-      'CLAUDE.md',
-      'test/fixtures/**',
-      'playground/**',
-      'docs/**',
-      'benchmark/**',
-    ],
-    rules: {
-      'no-use-before-define': 'off',
-      'node/prefer-global/process': 'off',
-      'node/prefer-global/buffer': 'off',
-      'ts/explicit-function-return-type': 'off',
-      'e18e/prefer-static-regex': 'off',
-    },
+    vue: true,
   },
+  ...harlanzw({
+    // base covers fixtures and playground; docs is its own Nuxt Content site
+    base: { ignores: ['docs/**', 'benchmark/**'] },
+    link: true,
+    nuxt: true,
+    vue: true,
+  }),
   {
-    files: ['**/test/**/*.ts', '**/test/**/*.js'],
-    rules: {
-      'ts/no-unsafe-function-type': 'off',
-      'no-console': 'off',
-      'antfu/no-top-level-await': 'off',
-    },
-  },
-  ...harlanzw({ link: true, nuxt: true, vue: true }),
-  {
+    // module and Nitro code, so a `useX` name is not a Vue composable
     files: ['**/server/**/*.ts', '**/src/**/*.ts'],
     rules: {
       'harlanzw/vue-no-faux-composables': 'off',
-    },
-  },
-  {
-    files: ['examples/**/package.json'],
-    rules: {
-      'pnpm/json-enforce-catalog': 'off',
-      'pnpm/json-valid-catalog': 'off',
-      'pnpm/json-prefer-workspace-settings': 'off',
     },
   },
 )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,8 +58,8 @@ catalogs:
       specifier: ^10.8.1
       version: 10.8.1
     eslint-plugin-harlanzw:
-      specifier: ^0.19.0
-      version: 0.19.0
+      specifier: ^0.19.2
+      version: 0.19.2
     fast-xml-parser:
       specifier: ^5.10.1
       version: 5.10.1
@@ -213,7 +213,7 @@ importers:
         version: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       eslint-plugin-harlanzw:
         specifier: 'catalog:'
-        version: 0.19.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
+        version: 0.19.2(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
       happy-dom:
         specifier: 'catalog:'
         version: 20.11.2
@@ -4285,8 +4285,8 @@ packages:
     peerDependencies:
       eslint: '>=8'
 
-  eslint-plugin-harlanzw@0.19.0:
-    resolution: {integrity: sha512-Y/fxnaU7J3P9J45RQnlnRo2WEgCXlP9xZD+qfE9UwIykIi4uHo/TeH5qJMYLN8ghQCqyF5alasxHRlAU6nHh7g==}
+  eslint-plugin-harlanzw@0.19.2:
+    resolution: {integrity: sha512-aXVG5dupBlq2Nn94ffBcxw6iSK7OoFoPriWQW2RlE2FHP8PiQt2hfOU1AxuYk0GqgNMIL9c3cKwdhw1RgyeRcw==}
     peerDependencies:
       eslint: '>=9.0.0'
 
@@ -12423,7 +12423,7 @@ snapshots:
       eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       eslint-compat-utils: 0.5.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
 
-  eslint-plugin-harlanzw@0.19.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2)):
+  eslint-plugin-harlanzw@0.19.2(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2)):
     dependencies:
       '@eslint/plugin-kit': 0.7.2
       eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,8 +58,8 @@ catalogs:
       specifier: ^10.8.1
       version: 10.8.1
     eslint-plugin-harlanzw:
-      specifier: ^0.18.1
-      version: 0.18.1
+      specifier: ^0.19.0
+      version: 0.19.0
     fast-xml-parser:
       specifier: ^5.10.1
       version: 5.10.1
@@ -213,7 +213,7 @@ importers:
         version: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       eslint-plugin-harlanzw:
         specifier: 'catalog:'
-        version: 0.18.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
+        version: 0.19.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
       happy-dom:
         specifier: 'catalog:'
         version: 20.11.2
@@ -4285,8 +4285,8 @@ packages:
     peerDependencies:
       eslint: '>=8'
 
-  eslint-plugin-harlanzw@0.18.1:
-    resolution: {integrity: sha512-w2xMDe3zuGPUDO+8GfGUrvUg447XJHqRi6U+IuH/HgsADRqo8SmC4GsQuxKaXq7YdkLe8eYjTtrGYDt/YwnpHw==}
+  eslint-plugin-harlanzw@0.19.0:
+    resolution: {integrity: sha512-Y/fxnaU7J3P9J45RQnlnRo2WEgCXlP9xZD+qfE9UwIykIi4uHo/TeH5qJMYLN8ghQCqyF5alasxHRlAU6nHh7g==}
     peerDependencies:
       eslint: '>=9.0.0'
 
@@ -12423,7 +12423,7 @@ snapshots:
       eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       eslint-compat-utils: 0.5.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
 
-  eslint-plugin-harlanzw@0.18.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2)):
+  eslint-plugin-harlanzw@0.19.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2)):
     dependencies:
       '@eslint/plugin-kit': 0.7.2
       eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,8 +58,8 @@ catalogs:
       specifier: ^10.8.1
       version: 10.8.1
     eslint-plugin-harlanzw:
-      specifier: ^0.17.1
-      version: 0.17.1
+      specifier: ^0.18.1
+      version: 0.18.1
     fast-xml-parser:
       specifier: ^5.10.1
       version: 5.10.1
@@ -213,7 +213,7 @@ importers:
         version: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       eslint-plugin-harlanzw:
         specifier: 'catalog:'
-        version: 0.17.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
+        version: 0.18.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
       happy-dom:
         specifier: 'catalog:'
         version: 20.11.2
@@ -4285,8 +4285,8 @@ packages:
     peerDependencies:
       eslint: '>=8'
 
-  eslint-plugin-harlanzw@0.17.1:
-    resolution: {integrity: sha512-JTqWyTYDdMGvo5RDQ1ugq8Y2hGhcSL432WZX3ls52Ie5e+L2MncacI5OrArWB6/8pO7pK3qdm+hgiaFVXmmHxw==}
+  eslint-plugin-harlanzw@0.18.1:
+    resolution: {integrity: sha512-w2xMDe3zuGPUDO+8GfGUrvUg447XJHqRi6U+IuH/HgsADRqo8SmC4GsQuxKaXq7YdkLe8eYjTtrGYDt/YwnpHw==}
     peerDependencies:
       eslint: '>=9.0.0'
 
@@ -9515,7 +9515,7 @@ snapshots:
 
   '@nuxt/schema@4.5.2':
     dependencies:
-      '@vue/shared': 3.5.40
+      '@vue/shared': 3.5.41
       defu: 6.1.7
       nostics: 1.2.0
       pathe: 2.0.3
@@ -11196,7 +11196,7 @@ snapshots:
 
   '@vue-macros/common@3.1.4(vue@3.5.40(typescript@6.0.3))':
     dependencies:
-      '@vue/compiler-sfc': 3.5.40
+      '@vue/compiler-sfc': 3.5.41
       ast-kit: 2.2.0
       local-pkg: 1.2.1
       magic-string-ast: 1.0.3
@@ -11206,7 +11206,7 @@ snapshots:
 
   '@vue-macros/common@3.1.4(vue@3.5.41(typescript@6.0.3))':
     dependencies:
-      '@vue/compiler-sfc': 3.5.40
+      '@vue/compiler-sfc': 3.5.41
       ast-kit: 2.2.0
       local-pkg: 1.2.1
       magic-string-ast: 1.0.3
@@ -11327,8 +11327,8 @@ snapshots:
   '@vue/language-core@3.3.9':
     dependencies:
       '@volar/language-core': 2.4.28
-      '@vue/compiler-dom': 3.5.40
-      '@vue/shared': 3.5.40
+      '@vue/compiler-dom': 3.5.41
+      '@vue/shared': 3.5.41
       alien-signals: 3.2.1
       muggle-string: 0.4.1
       path-browserify: 1.0.1
@@ -12423,7 +12423,7 @@ snapshots:
       eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       eslint-compat-utils: 0.5.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
 
-  eslint-plugin-harlanzw@0.17.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2)):
+  eslint-plugin-harlanzw@0.18.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2)):
     dependencies:
       '@eslint/plugin-kit': 0.7.2
       eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,7 +23,7 @@ minimumReleaseAgeExclude:
   - '@nuxt/schema@4.5.0'
   - '@nuxt/vite-builder@4.5.0'
   - nuxt@4.5.0
-  - eslint-plugin-harlanzw@0.18.1
+  - eslint-plugin-harlanzw@0.19.0
 shellEmulator: true
 
 trustPolicy: no-downgrade
@@ -62,7 +62,7 @@ catalog:
   consola: ^3.4.2
   defu: ^6.1.7
   eslint: ^10.8.1
-  eslint-plugin-harlanzw: ^0.18.1
+  eslint-plugin-harlanzw: ^0.19.0
   fast-xml-parser: ^5.10.1
   happy-dom: ^20.11.2
   nuxt: ^4.5.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,7 +23,7 @@ minimumReleaseAgeExclude:
   - '@nuxt/schema@4.5.0'
   - '@nuxt/vite-builder@4.5.0'
   - nuxt@4.5.0
-  - eslint-plugin-harlanzw@0.19.0
+  - eslint-plugin-harlanzw@0.19.2
 shellEmulator: true
 
 trustPolicy: no-downgrade
@@ -62,7 +62,7 @@ catalog:
   consola: ^3.4.2
   defu: ^6.1.7
   eslint: ^10.8.1
-  eslint-plugin-harlanzw: ^0.19.0
+  eslint-plugin-harlanzw: ^0.19.2
   fast-xml-parser: ^5.10.1
   happy-dom: ^20.11.2
   nuxt: ^4.5.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,6 +23,7 @@ minimumReleaseAgeExclude:
   - '@nuxt/schema@4.5.0'
   - '@nuxt/vite-builder@4.5.0'
   - nuxt@4.5.0
+  - eslint-plugin-harlanzw@0.18.1
 shellEmulator: true
 
 trustPolicy: no-downgrade
@@ -61,7 +62,7 @@ catalog:
   consola: ^3.4.2
   defu: ^6.1.7
   eslint: ^10.8.1
-  eslint-plugin-harlanzw: ^0.17.1
+  eslint-plugin-harlanzw: ^0.18.1
   fast-xml-parser: ^5.10.1
   happy-dom: ^20.11.2
   nuxt: ^4.5.2


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`eslint.config.mjs` carried the same ignore list, node-globals overrides, test-file relaxation and `examples/*/package.json` catalog exemptions that every one of my repos had pasted into it. `eslint-plugin-harlanzw` 0.19.2 ships those as `base()`, so this repo now opts in instead of restating them. Same shape as nuxt-seo#619.

45 config lines down to 23. Repo-specific bits stay inline: the `docs/**` and `benchmark/**` ignores go through `base.ignores`, and the `harlanzw/vue-no-faux-composables` disable for `src`/`server` stays as its own block.

Resolved severity, compared with `eslint --print-config` on the same plugin version so only the config change shows:

- `ts/no-use-before-define`: error → off, everywhere. The old config only turned off the core rule, and the TS variant is the one that actually fires.
- `src/templates.test.ts` picks up the test relaxation (`no-console`, `ts/no-unsafe-function-type`). Base matches `**/*.test.ts` anywhere; the old glob was `**/test/**` only, so this file was never covered.

Nothing else moved. `eslint . -f json` lints the same 230 files before and after with the same two messages, both `harlanzw/prefer-satisfies` warnings that arrived with the 0.17.1 → 0.19.2 bump and are unrelated to the config rewrite.

Two no-ops worth calling out:

- `e18e/prefer-static-regex: 'off'` at the top level is gone. It resolves to `off` without the entry, so it was never doing anything.
- `vue: true` is now passed to `antfu()` to match the template, but the resolved config for `devtools/pages/sitemap.vue` is identical either way, so antfu was already detecting Vue.

`base()` also normalises `agentFiles` to `lint` when the prompt rules are on, which would put `CLAUDE.md` / `AGENTS.md` in the lint run. Neither file is tracked here, so there was nothing to fix and I left the default alone.

`pnpm test` is not run locally on this branch: the script packs the module and installs the nuxt5 fixture, which is a long network-bound build for a config-only diff. CI covers it.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).



