### PR TITLE
test(sitemap): IPv6 localhost regression coverage for multi sitemap index (#594)

### DIFF
--- a/test/e2e/issues/issue-594.test.ts
+++ b/test/e2e/issues/issue-594.test.ts
@@ -1,0 +1,33 @@
+import { createResolver } from '@nuxt/kit'
+import { $fetch, setup } from '@nuxt/test-utils'
+import { describe, expect, it } from 'vitest'
+
+const { resolve } = createResolver(import.meta.url)
+
+await setup({
+  rootDir: resolve('../../fixtures/issue-594'),
+  server: true,
+  dev: true,
+})
+
+describe.skipIf(process.env.CI)('issue #594 - multi sitemap links on localhost', () => {
+  it('index entries keep a usable http origin when browsed via [::1]', async () => {
+    // no site url configured + dev mode: the index must fall back to the nitro origin.
+    // regression: nuxt-site-config-kit < 4 mangled [::1] hosts into https://[::1]:3000 links
+    const sitemap: string = await $fetch('/sitemap_index.xml', {
+      headers: { host: '[::1]:3000' },
+    })
+
+    expect(sitemap).toContain('<sitemapindex')
+    expect(sitemap).toMatch(/<loc>http:\/\/(?:localhost|127\.0\.0\.1)(?::\d+)?\/__sitemap__\/sitemap-da\.xml<\/loc>/)
+    expect(sitemap).toMatch(/<loc>http:\/\/(?:localhost|127\.0\.0\.1)(?::\d+)?\/__sitemap__\/sitemap-en\.xml<\/loc>/)
+    expect(sitemap).not.toContain('https://')
+    expect(sitemap).not.toContain('[::1]')
+  }, 120000)
+
+  it('child sitemaps are served at the paths the index links to', async () => {
+    const sitemap: string = await $fetch('/__sitemap__/sitemap-da.xml')
+    expect(sitemap).toContain('<urlset')
+    expect(sitemap).toContain('/da')
+  }, 60000)
+})

--- a/test/fixtures/issue-594/app.vue
+++ b/test/fixtures/issue-594/app.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>issue-594 fixture</div>
+</template>

--- a/test/fixtures/issue-594/nuxt.config.ts
+++ b/test/fixtures/issue-594/nuxt.config.ts
@@ -1,0 +1,24 @@
+import NuxtSitemap from '../../../src/module'
+
+export default defineNuxtConfig({
+  modules: [
+    NuxtSitemap,
+  ],
+
+  // no site url: forces the sitemap to fall back to the request origin in dev
+  compatibilityDate: '2025-01-15',
+
+  sitemap: {
+    // mirrors the multi source setup from the issue
+    sitemaps: {
+      'sitemap-da': {
+        urls: ['/da'],
+      },
+      'sitemap-en': {
+        urls: ['/en'],
+      },
+    },
+    autoLastmod: false,
+    credits: false,
+  },
+})


### PR DESCRIPTION
## Context

Regression coverage for #594. No module code change is needed on main.

On `@nuxtjs/sitemap` 7.6.0, browsing the dev server via `[::1]:3000` made the sitemap index emit broken links:

```xml
<loc>https://[::1]:3000/__sitemap__/sitemap-da.xml</loc>
```

## Root cause

`nuxt-site-config-kit@3.2.18` (pulled in by `nuxt-site-config@3.2.18`, the version 7.6.0 resolved):

1. `ctx.requestHost.split(":")[0]` turns `[::1]:3000` into `[`, which fails the localhost check. The raw IPv6 host then overrides the dev origin.
2. The final branch forces `protocol = "https"` for any host that is not `localhost` or `127.*`.

Result: `https://[::1]:3000/` links on an HTTP dev server.

Fixed upstream in `nuxt-site-config-kit` 3.2.21+ and 4.x (`isLocalhostHost` / `extractHostname` / `splitHostPort` handle bracketed IPv6 hosts). This module already pins `nuxt-site-config@^4.2.3`, so current v8 emits usable links.

## What this PR does

- Adds `test/fixtures/issue-594`: dev fixture with no site URL and a multi sitemap setup mirroring the issue.
- Adds `test/e2e/issues/issue-594.test.ts`: requests `/sitemap_index.xml` with `Host: [::1]:3000` and asserts index entries use a usable `http` loopback origin (no `https`, no bracketed host). Also asserts the child sitemaps are served at the paths the index links to.

The test fails against the 7.6.0 behavior and passes on main.

## For 7.x users

The fix ships in `nuxt-site-config-kit >= 3.2.21`. Since 7.6.0 declares `nuxt-site-config: ^3.2.18`, a fresh install resolves a fixed version; only lockfiles pinned to 3.2.18 keep the bug. Affected users can refresh the lockfile or upgrade to v8.
